### PR TITLE
Fixe Oracle CLOB save by using PDO bindParam

### DIFF
--- a/runtime/lib/adapter/DBOracle.php
+++ b/runtime/lib/adapter/DBOracle.php
@@ -225,9 +225,6 @@ class DBOracle extends DBAdapter
 		if ($cMap->isTemporal()) {
 			$value = $this->formatTemporalValue($value, $cMap);
 		} elseif ($cMap->getType() == PropelColumnTypes::CLOB_EMU) {
-			// we always need to make sure that the stream is rewound, otherwise nothing will
-			// get written to database.
-			rewind($value);
 			return $stmt->bindParam(':p'.$position, $value, $cMap->getPdoType(), strlen($value));
 		} elseif (is_resource($value) && $cMap->isLob()) {
 			// we always need to make sure that the stream is rewound, otherwise nothing will


### PR DESCRIPTION
CLOB save with Oracle generate an error :

PDOException: SQLSTATE[HY000]: General error: 1461 OCIStmtExecute: ORA-01461: can bind a LONG value only for insert into a LONG column

By overloading BindValue function in adapter DBOracle.php we can use bindParam instead of bindValue correct the error
