### PR TITLE
Fixed Error in logic of _if/_elseif/_else.

### DIFF
--- a/runtime/lib/util/PropelConditionalProxy.php
+++ b/runtime/lib/util/PropelConditionalProxy.php
@@ -40,28 +40,24 @@ class PropelConditionalProxy
 		$this->mainObject = $mainObject;
 	}
 	
-	public function _if()
+	public function _if($cond)
 	{
-		throw new PropelException('_if() statements cannot be nested');
+		return $this->mainObject->_if($cond);
 	}
 	
 	public function _elseif($cond)
 	{
-		if($cond) {
-			return $this->mainObject;
-		} else {
-			return $this;
-		}
+		return $this->mainObject->_elseif($cond);
 	}
 	
 	public function _else()
 	{
-		return $this->mainObject;
+		return $this->mainObject->_else();
 	}
 	
 	public function _endif()
 	{
-		return $this->mainObject;
+		return $this->mainObject->_endif();
 	}
 	
 	public function __call($name, $arguments)

--- a/test/testsuite/runtime/query/CriteriaFluidConditionTest.php
+++ b/test/testsuite/runtime/query/CriteriaFluidConditionTest.php
@@ -64,6 +64,19 @@ class CriteriaFluidConditionTest extends BaseTestCase
 			_endif();
 	}
 
+	/**
+	 * @expectedException PropelException
+	 */
+	public function testNestedIf2()
+	{
+		$f = new TestableCriteria();
+		$f->
+			_if(true)->
+			_if(true)->
+				test()->
+			_endif();
+	}
+
 	public function testElseIf()
 	{
 		$f = new TestableCriteria();
@@ -77,6 +90,14 @@ class CriteriaFluidConditionTest extends BaseTestCase
 		$f->
 			_if(true)->
 			_elseif(false)->
+				test()->
+			_endif();
+		$this->assertFalse($f->getTest(), '_elseif() does not execute the next method if the main test is true');
+		$f = new TestableCriteria();
+		$f->
+			_if(true)->
+			_elseif(false)->
+			_elseif(true)->
 				test()->
 			_endif();
 		$this->assertFalse($f->getTest(), '_elseif() does not execute the next method if the main test is true');
@@ -120,6 +141,16 @@ class CriteriaFluidConditionTest extends BaseTestCase
 				test()->
 			_endif();
 		$this->assertFalse($f->getTest(), '_else() does not execute the next method if the previous test is true');
+		$f = new TestableCriteria();
+		$f->
+			_if(false)->
+			_elseif(true)->
+			_elseif(true)->
+			_else()->
+				test()->
+			_endif();
+		$this->assertFalse($f->getTest(), '_else() does not execute the next method if the previous test is true');
+		$f = new TestableCriteria();
 		$f->
 			_if(false)->
 			_elseif(false)->


### PR DESCRIPTION
Based on a patch by lvu, updated to Propel standards.
Closes #12
