### PR TITLE
added missing validator in autoload map

### DIFF
--- a/runtime/lib/Propel.php
+++ b/runtime/lib/Propel.php
@@ -248,6 +248,7 @@ class Propel
 		'MinValueValidator'   => 'validator/MinValueValidator.php',
 		'NotMatchValidator'   => 'validator/NotMatchValidator.php',
 		'RequiredValidator'   => 'validator/RequiredValidator.php',
+		'TypeValidator'       => 'validator/TypeValidator.php',
 		'UniqueValidator'     => 'validator/UniqueValidator.php',
 		'ValidValuesValidator' => 'validator/ValidValuesValidator.php',
 		'ValidationFailed'    => 'validator/ValidationFailed.php',


### PR DESCRIPTION
Fixes a bug raised on the developers mailing-list about a validator not autoloaded by Propel.
