### PR TITLE
False positives in Diff-task with composite foreign-keys on PostgreSQL

### DIFF
--- a/generator/lib/model/diff/PropelForeignKeyComparator.php
+++ b/generator/lib/model/diff/PropelForeignKeyComparator.php
@@ -47,10 +47,18 @@ class PropelForeignKeyComparator
 		}
 		
 		// compare columns
-		if (array_map('strtolower', $fromFk->getLocalColumns()) != array_map('strtolower', $toFk->getLocalColumns())) {
+		$fromFkLocalColumns = $fromFk->getLocalColumns();
+		sort($fromFkLocalColumns);
+		$toFkLocalColumns = $toFk->getLocalColumns();
+		sort($toFkLocalColumns);
+		if (array_map('strtolower', $fromFkLocalColumns) != array_map('strtolower', $toFkLocalColumns)) {
 			return true;
 		}
-		if (array_map('strtolower', $fromFk->getForeignColumns()) != array_map('strtolower', $toFk->getForeignColumns())) {
+		$fromFkForeignColumns = $fromFk->getForeignColumns();
+		sort($fromFkForeignColumns);
+		$toFkForeignColumns = $toFk->getForeignColumns();
+		sort($toFkForeignColumns);
+		if (array_map('strtolower', $fromFkForeignColumns) != array_map('strtolower', $toFkForeignColumns)) {
 			return true;
 		}
 		


### PR DESCRIPTION
[Imported from http://www.propelorm.org/ticket/1458]

If foreign keys contain more than one column it might be, that they get re-generated.

Re-produce schema on PostgreSQL:

``` xml
<table name="product">
                <!-- something cutted -->
        <column name="system_customer_id" type="INTEGER" required="true" primaryKey="true" />
        <column name="product_group_id" type="VARCHAR" size="10" />
                <!-- something cutted -->

        <foreign-key foreignTable="product_group">
            <reference local="system_customer_id" foreign="system_customer_id" />
            <reference local="product_group_id" foreign="id" />
        </foreign-key>
</table>
```

The diff task always drops and adds the foreign-key constraint.

The fix is easy, just sort the columns when comparing.
