### PR TITLE
Limit parameter in clear()

### DIFF
--- a/runtime/lib/query/Criteria.php
+++ b/runtime/lib/query/Criteria.php
@@ -292,7 +292,7 @@ class Criteria implements IteratorAggregate
 		$this->selectQueries = array();
 		$this->dbName = $this->originalDbName;
 		$this->offset = 0;
-		$this->limit = -1;
+		$this->limit = 0;
 		$this->blobFlag = null;
 		$this->aliases = array();
 		$this->useTransaction = false;


### PR DESCRIPTION
The limit parameter is set to 0 intially, but overwritten with -1 if the clear() function is called. This leads to strange results, e.g. a count() after a clear will always return a 0 (because the limit parameter of -1 will be included in the resulting sql)
