### PR TITLE
Fixed Typo in the doc related to ModelCriteria::addSelectQuery() in 1.6

### DIFF
--- a/WHATS_NEW
+++ b/WHATS_NEW
@@ -710,7 +710,7 @@ $latestBooks = BookQuery::create()
   ->withColumn('MAX(Book.CreatedAt)')
   ->groupBy('Book.AuthorId');
 $latestCheapBooks = BookQuery::create()
-  ->useSelectQuery($latestBooks, 'lastBook')
+  ->addSelectQuery($latestBooks, 'lastBook')
   ->where('lastBook.Price < ?', 20)
   ->find();
 }}}

--- a/docs/reference/ModelCriteria.txt
+++ b/docs/reference/ModelCriteria.txt
@@ -953,7 +953,7 @@ $latestBooks = BookQuery::create()
   ->withColumn('MAX(Book.CreatedAt)')
   ->groupBy('Book.AuthorId');
 $latestCheapBooks = BookQuery::create()
-  ->useSelectQuery($latestBooks, 'lastBook')
+  ->addSelectQuery($latestBooks, 'lastBook')
   ->where('lastBook.Price < ?', 20)
   ->find();
 }}}


### PR DESCRIPTION
Fixed Typo in the doc mixing `ModelCriteria::addSelectQuery()` with `ModelCriteria::getSelectQuery()`.

Related Trac ticket: http://www.propelorm.org/ticket/1457
