### PR TITLE
Allow configuration of usePrefix and includeLazyLoadColumns when exporting a PropelCollection

### DIFF
--- a/runtime/lib/om/BaseObject.php
+++ b/runtime/lib/om/BaseObject.php
@@ -16,10 +16,10 @@
  * @method     BaseObject fromYAML(string $data) Populate the object from a YAML string
  * @method     BaseObject fromJSON(string $data) Populate the object from a JSON string
  * @method     BaseObject fromCSV(string $data) Populate the object from a CSV string
- * @method     string toXML() Export the object to an XML string
- * @method     string toYAML() Export the object to a YAML string
- * @method     string toJSON() Export the object to a JSON string
- * @method     string toCSV() Export the object to a CSV string
+ * @method     string toXML(boolean $includeLazyLoadColumns) Export the object to an XML string
+ * @method     string toYAML(boolean $includeLazyLoadColumns) Export the object to a YAML string
+ * @method     string toJSON(boolean $includeLazyLoadColumns) Export the object to a JSON string
+ * @method     string toCSV(boolean $includeLazyLoadColumns) Export the object to a CSV string
  *
  * @author     Hans Lellelid <hans@xmpl.org> (Propel)
  * @author     Frank Y. Kim <frank.kim@clearink.com> (Torque)
@@ -344,16 +344,16 @@ abstract class BaseObject
 	 *  => {"Id":9012,"Title":"Don Juan","ISBN":"0140422161","Price":12.99,"PublisherId":1234,"AuthorId":5678}');
 	 * </code>
 	 *
-	 * @param  mixed  $parser A PropelParser instance,
-	 *                        or a format name ('XML', 'YAML', 'JSON', 'CSV')
-	 * @return string The exported data
+	 * @param     mixed   $parser                 A PropelParser instance, or a format name ('XML', 'YAML', 'JSON', 'CSV')
+	 * @param     boolean $includeLazyLoadColumns (optional) Whether to include lazy load(ed) columns. Defaults to TRUE.
+	 * @return    string                          The exported data
 	 */
-	public function exportTo($parser)
+	public function exportTo($parser, $includeLazyLoadColumns = true)
 	{
 		if (!$parser instanceof PropelParser) {
 			$parser = PropelParser::getParser($parser);
 		}
-		return $parser->fromArray($this->toArray(BasePeer::TYPE_PHPNAME, true, array(), true));
+		return $parser->fromArray($this->toArray(BasePeer::TYPE_PHPNAME, $includeLazyLoadColumns, array(), true));
 	}
 
 	/**
@@ -368,9 +368,14 @@ abstract class BaseObject
 
 	/**
 	 * Catches calls to undefined methods.
-	 * Provides magic getter for virtual columns.
+	 *
 	 * Provides magic import/export method support (fromXML()/toXML(), fromYAML()/toYAML(), etc.).
 	 * Allows to define default __call() behavior if you use a custom BaseObject
+	 *
+	 * @param	string  $name
+	 * @param   mixed   $params
+	 *
+	 * @return	array|string
 	 */
 	public function __call($name, $params)
 	{
@@ -389,7 +394,8 @@ abstract class BaseObject
 			return $this->importFrom($matches[1], reset($params));
 		}
 		if (preg_match('/^to(\w+)$/', $name, $matches)) {
-			return $this->exportTo($matches[1]);
+ 			$includeLazyLoadColumns = isset($params[0]) && is_bool($params[0]) ? $params[0] : true;
+ 			return $this->exportTo($matches[1], $includeLazyLoadColumns);
 		}
 		throw new PropelException('Call to undefined method: ' . $name);
 	}


### PR DESCRIPTION
I just added the patch attached with the ticket 1413. From what I read and tested, it's pretty consistent and without any side effects.

See: http://www.propelorm.org/ticket/1413
