### PR TITLE
Fixed TINYINT interpretation in MysqlSchemaParser

### DIFF
--- a/generator/lib/reverse/mysql/MysqlSchemaParser.php
+++ b/generator/lib/reverse/mysql/MysqlSchemaParser.php
@@ -63,7 +63,7 @@ class MysqlSchemaParser extends BaseSchemaParser
 
 	protected static $defaultTypeSizes = array(
 		'char'     => 1,
-		'tinyint'  => 2,
+		'tinyint'  => 4,
 		'smallint' => 6,
 		'int'      => 11,
 		'bigint'   => 20,


### PR DESCRIPTION
Before, TINYINT was always treated as BOOLEAN which is wrong.
Now, TINYINT(1) are treated as BOOLEAN and all others TINYINTs will be treated as TINYINTs.

Should fix #36
