### PR TITLE
Removed __call() from generated ActiveRecord classes.

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -4712,27 +4712,19 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 	 */
 	protected function addMagicCall(&$script)
 	{
-		$script .= "
+		$behaviorCallScript = '';
+		$this->applyBehaviorModifier('objectCall', $behaviorCallScript, "		");
+		if ($behaviorCallScript) {
+			$script .= "
 	/**
 	 * Catches calls to virtual methods
 	 */
 	public function __call(\$name, \$params)
-	{";
-		$this->applyBehaviorModifier('objectCall', $script, "		");
-		$script .= "
-		if (preg_match('/get(\w+)/', \$name, \$matches)) {
-			\$virtualColumn = \$matches[1];
-			if (\$this->hasVirtualColumn(\$virtualColumn)) {
-				return \$this->getVirtualColumn(\$virtualColumn);
-			}
-			// no lcfirst in php<5.3...
-			\$virtualColumn[0] = strtolower(\$virtualColumn[0]);
-			if (\$this->hasVirtualColumn(\$virtualColumn)) {
-				return \$this->getVirtualColumn(\$virtualColumn);
-			}
-		}
+	{
+		$behaviorCallScript
 		return parent::__call(\$name, \$params);
 	}
 ";
+		}
 	}
 } // PHP5ObjectBuilder

--- a/runtime/lib/om/BaseObject.php
+++ b/runtime/lib/om/BaseObject.php
@@ -368,11 +368,23 @@ abstract class BaseObject
 
 	/**
 	 * Catches calls to undefined methods.
+	 * Provides magic getter for virtual columns.
 	 * Provides magic import/export method support (fromXML()/toXML(), fromYAML()/toYAML(), etc.).
 	 * Allows to define default __call() behavior if you use a custom BaseObject
 	 */
 	public function __call($name, $params)
 	{
+		if (preg_match('/get(\w+)/', $name, $matches)) {
+			$virtualColumn = $matches[1];
+			if ($this->hasVirtualColumn($virtualColumn)) {
+				return $this->getVirtualColumn($virtualColumn);
+			}
+			// no lcfirst in php<5.3...
+			$virtualColumn[0] = strtolower($virtualColumn[0]);
+			if ($this->hasVirtualColumn($virtualColumn)) {
+				return $this->getVirtualColumn($virtualColumn);
+			}
+		}
 		if (preg_match('/^from(\w+)$/', $name, $matches)) {
 			return $this->importFrom($matches[1], reset($params));
 		}


### PR DESCRIPTION
The method gets generated only if a behavior implements the "objectCall" hook.
Otherwise, the logic that was previously in the generated _call() method,
used to deal with virtual column getters, is handled by BaseObject.

This commit should unclutter generated AR classs a bit, and use inheritance
when it makes sense (i.e. no variations in code depending on the model).
