### PR TITLE
Fixed MySQL type for a BOOLEAN

### DIFF
--- a/generator/lib/platform/MysqlPlatform.php
+++ b/generator/lib/platform/MysqlPlatform.php
@@ -30,7 +30,7 @@ class MysqlPlatform extends DefaultPlatform
 	protected function initialize()
 	{
 		parent::initialize();
-		$this->setSchemaDomainMapping(new Domain(PropelTypes::BOOLEAN, "TINYINT"));
+		$this->setSchemaDomainMapping(new Domain(PropelTypes::BOOLEAN, "TINYINT", 1));
 		$this->setSchemaDomainMapping(new Domain(PropelTypes::NUMERIC, "DECIMAL"));
 		$this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, "TEXT"));
 		$this->setSchemaDomainMapping(new Domain(PropelTypes::BINARY, "BLOB"));


### PR DESCRIPTION
Related to PR #43.

It fixes the BOOLEAN type for MySQL as recommended AFAIK. See #43 for more details.
