### PR TITLE
[1.6.2] Detect autoincrement for Oracle via sequences

### DIFF
--- a/generator/default.properties
+++ b/generator/default.properties
@@ -262,6 +262,15 @@ propel.mysql.tableEngineKeyword = ENGINE
 
 # -------------------------------------------------------------------
 #
+#  O R A C L E   S P E C I F I C   S E T T I N G S
+#
+# -------------------------------------------------------------------
+
+# Pattern for sequences which will be used for autoincrement columns
+propel.oracle.autoincrementSequencePattern = ${table}_SEQ
+
+# -------------------------------------------------------------------
+#
 #  D B D E S I G N E R   2   P R O P E L   S E T T I N G S
 #
 # -------------------------------------------------------------------

--- a/generator/lib/reverse/oracle/OracleSchemaParser.php
+++ b/generator/lib/reverse/oracle/OracleSchemaParser.php
@@ -75,6 +75,10 @@ class OracleSchemaParser extends BaseSchemaParser
 		$tables = array();
 		$stmt = $this->dbh->query("SELECT OBJECT_NAME FROM USER_OBJECTS WHERE OBJECT_TYPE = 'TABLE'");
 
+		$seqPattern = $this->getGeneratorConfig()->getBuildProperty(
+			'oracleAutoincrementSequencePattern'
+		);
+
 		if ($task) $task->log("Reverse Engineering Table Structures", Project::MSG_VERBOSE);
 		// First load the tables (important that this happen before filling out details of tables)
 		while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
@@ -95,14 +99,17 @@ class OracleSchemaParser extends BaseSchemaParser
 			$this->addIndexes($table);
 
 			$pkColumns = $table->getPrimaryKey();
-			if (count($pkColumns) == 1) {
-				$stmt2 = $this->dbh->query("SELECT * FROM USER_SEQUENCES WHERE SEQUENCE_NAME = '" . $table->getName() . "_SEQ'");
+			if (count($pkColumns) == 1 && $seqPattern) {
+				$seqName = str_replace('${table}', $tableName, $seqPattern);
+				$seqName = strtoupper($seqName);
+
+				$stmt2 = $this->dbh->query("SELECT * FROM USER_SEQUENCES WHERE SEQUENCE_NAME = '" . $seqName . "'");
 				$hasSeq = $stmt2->fetch(PDO::FETCH_ASSOC);
 
 				if ($hasSeq) {
 					$pkColumns[0]->setAutoIncrement(true);
 					$idMethodParameter = new IdMethodParameter();
-					$idMethodParameter->setValue($table->getName() . '_SEQ');
+					$idMethodParameter->setValue($seqName);
 					$table->addIdMethodParameter($idMethodParameter);
 				}
 			}
@@ -175,7 +182,7 @@ class OracleSchemaParser extends BaseSchemaParser
 			if ($default !== null) {
 				$column->getDomain()->setDefaultValue(new ColumnDefaultValue($default, ColumnDefaultValue::TYPE_VALUE));
 			}
-			$column->setAutoIncrement(false); // This flag sets in self::parse() 
+			$column->setAutoIncrement(false); // This flag sets in self::parse()
 			$column->setNotNull(!$isNullable);
 			$table->addColumn($column);
 		}


### PR DESCRIPTION
Unfortunately, this solution allow autoincrement only for primary keys on one column.
How to use:
For table TEST_TABLE you must define numeric primary key column. Also sequence named TEST_TABLE_SEQ must exist. After reverse task you will got in your schema.xml record like this:
`<table name="TEST_TABLE" phpName="TestTable">
  <column name="ID" phpName="Id" type="BIGINT" size="20" scale="0" primaryKey="true" autoIncrement="true" required="true"/>
  <id-method-parameter value="TEST_TABLE_SEQ"/>
  <index name="PK_TEST_TABLE">
    <index-column name="ID"/>
  </index>
</table>`

Maybe sequence name pattern should be configurable, what do you think about it?
