### PR TITLE
Use PropelTypes::DATE instead of PropelTypes::TIMESTAMP for DATE columns in OracleSchemaParser

### DIFF
--- a/generator/lib/reverse/oracle/OracleSchemaParser.php
+++ b/generator/lib/reverse/oracle/OracleSchemaParser.php
@@ -42,7 +42,7 @@ class OracleSchemaParser extends BaseSchemaParser
 		'BLOB'		=> PropelTypes::BLOB,
 		'CHAR'		=> PropelTypes::CHAR,
 		'CLOB'		=> PropelTypes::CLOB,
-		'DATE'		=> PropelTypes::TIMESTAMP,
+		'DATE'		=> PropelTypes::DATE,
 		'BIGINT'	=> PropelTypes::BIGINT,
 		'DECIMAL'	=> PropelTypes::DECIMAL,
 		'DOUBLE'	=> PropelTypes::DOUBLE,


### PR DESCRIPTION
Currently by some strange reason `timestamp` is used for date column. When trying to insert value '01-01-2011 00:00:00' into date column we have got an error (SQL Error: ORA-01830: date format picture ends before converting entire input string).
