### PR TITLE
Pass vendor`s type to VentorInfo::__construct() in XMLElement::getVendorInfoForType()

### DIFF
--- a/generator/lib/model/XMLElement.php
+++ b/generator/lib/model/XMLElement.php
@@ -126,7 +126,7 @@ abstract class XMLElement
 			return $this->vendorInfos[$type];
 		} else {
 			// return an empty object
-			return new VendorInfo();
+			return new VendorInfo($type);
 		}
 	}
 


### PR DESCRIPTION
Currently VendorInfo which has been instantiated in XMLElement::getVendorInfoForType() has type == null instead of requested $type.
