### PR TITLE
fixed #70 : setByPosition method in enum

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -2350,8 +2350,6 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 				\$valueSet = " . $this->getPeerClassname() . "::getValueSet(" . $this->getColumnConstant($col) . ");
 				if (isset(\$valueSet[\$value])) {
 					\$value = \$valueSet[\$value];
-				} else {
-					\$value = null;
 				}";
 			} elseif (PropelTypes::PHP_ARRAY === $col->getType()) {
 				$script .= "


### PR DESCRIPTION
if given values is not an ENUM element key, it was forced to null.
the validation is now left to the set[ColumnName] function.
translation is kept in case a key is given, that is mandatory for
database hydatation.
