### PR TITLE
Fixed build-sql with multiple schemas

### DIFF
--- a/generator/lib/task/PropelSQLTask.php
+++ b/generator/lib/task/PropelSQLTask.php
@@ -144,15 +144,21 @@ class PropelSQLTask extends AbstractPropelDataModelTask
 		foreach ($dataModels as $package => $dataModel) {
 
 			foreach ($dataModel->getDatabases() as $database) {
-
 				$platform = $database->getPlatform();
+
 				if (!$this->packageObjectModel) {
 					$name = $dataModel->getName();
 				} else {
 					$name = ($package ? $package . '.' : '') . 'schema.xml';
 				}
+
+				if (strpos($name, '/')) {
+					$name = substr($name, strrpos($name, '/'));
+				}
+
 				$outFile = $this->getMappedFile($name);
 				$absPath = $outFile->getAbsolutePath();
+
 				if ($this->getGeneratorConfig()->getBuildProperty('disableIdentifierQuoting')) {
 					$platform->setIdentifierQuoting(false);
 				}


### PR DESCRIPTION
Related to a bug with the PropelBundle; it's not really possible to generate SQL files based on the package value since we allowed to use slashes in it...

This "hack" solves the bug but... Let's see your comments.
