### PR TITLE
Incorrectly generated migration SQL for PostgreSQL when removing defaultValue from schema

### DIFF
--- a/generator/lib/platform/PgsqlPlatform.php
+++ b/generator/lib/platform/PgsqlPlatform.php
@@ -397,7 +397,11 @@ ALTER TABLE %s ALTER COLUMN %s;
 					$ret .= sprintf($pattern, $this->quoteIdentifier($table->getName()), $colName . ' TYPE ' . $sqlType);
 					break;
 				case 'defaultValueValue':
-					$ret .= sprintf($pattern, $this->quoteIdentifier($table->getName()), $colName . ' SET ' . $this->getColumnDefaultValueDDL($toColumn));
+					if ($property[0] !== null && $property[1] === null) {
+					    $ret .= sprintf($pattern, $this->quoteIdentifier($table->getName()), $colName . ' DROP DEFAULT');
+					} else {
+					    $ret .= sprintf($pattern, $this->quoteIdentifier($table->getName()), $colName . ' SET ' . $this->getColumnDefaultValueDDL($toColumn));
+					}
 					break;
 				case 'notNull':
 					$notNull = " DROP NOT NULL";

--- a/test/testsuite/generator/platform/PgsqlPlatformMigrationTest.php
+++ b/test/testsuite/generator/platform/PgsqlPlatformMigrationTest.php
@@ -361,5 +361,18 @@ EOF;
 		$expected = false;
 		$this->assertSame($expected, $columnDiff);
 	}
+
+	/**
+	 * @dataProvider providerForTestGetModifyColumnRemoveDefaultValueDDL
+	 */
+	public function testGetModifyColumnRemoveDefaultValueDDL($columnDiffs)
+	{
+	    $expected = <<<EOF
+
+ALTER TABLE "test" ALTER COLUMN "test" DROP DEFAULT;
+
+EOF;
+	    $this->assertEquals($expected, $this->getPlatform()->getModifyColumnDDL($columnDiffs));
+	}
 	
 }

--- a/test/testsuite/generator/platform/PlatformMigrationTestProvider.php
+++ b/test/testsuite/generator/platform/PlatformMigrationTestProvider.php
@@ -457,4 +457,20 @@ EOF;
 		return array(array(array($table->getColumn('bar1'), $table->getColumn('bar2'))));
 	}
 
+	public function providerForTestGetModifyColumnRemoveDefaultValueDDL()
+	{
+	    $t1 = new Table('test');
+	    $c1 = new Column();
+	    $c1->setName('test');
+	    $c1->getDomain()->setType('INTEGER');
+	    $c1->setDefaultValue(0);
+	    $t1->addColumn($c1);
+	    $t2 = new Table('test');
+	    $c2 = new Column();
+	    $c2->setName('test');
+	    $c2->getDomain()->setType('INTEGER');
+	    $t2->addColumn($c2);
+	    return array(array(PropelColumnComparator::computeDiff($c1, $c2)));
+	}
+
 }


### PR DESCRIPTION
The database migration generates incorrect SQL if a column has a defaultValue-attribute set which is then removed.

If we have a table like:

``` xml
<database name="test">
  <table name="test">
    <column name="test" primaryKey="true" type="integer" />
    <column name="test2" type="integer" defaultValue="0" />
  </table>
</database>
```

then generate the sql for it, add it to the database and change the schema to

``` xml
<database name="test">
  <table name="test">
    <column name="test" primaryKey="true" type="integer" />
    <column name="test2" type="integer"/>
  </table>
</database>
```

the expected result would be `ALTER TABLE "test" ALTER COLUMN "test2" DROP DEFAULT;`, but what is actually being generated is `ALTER TABLE "test" ALTER COLUMN "test2" SET ;`

This is because the migration code doesn't check if the default value is actually removed (`$properties[1]` contains `null`) so it always tries to set a default value.
