### PR TITLE
Making sure adding relatedby string when column name matches foreign table name.

### DIFF
--- a/generator/lib/builder/om/OMBuilder.php
+++ b/generator/lib/builder/om/OMBuilder.php
@@ -398,7 +398,7 @@ abstract class OMBuilder extends DataModelBuilder
 			}
 			if (count($localTable->getForeignKeysReferencingTable($fk->getForeignTableName())) > 1
 			 || count($fk->getForeignTable()->getForeignKeysReferencingTable($fk->getTableName())) > 0
-			 || $fk->getForeignTableName() == $fk->getTableName()) {
+			 || $fk->getForeignTableName() == $localColumnName) {
 				// self referential foreign key, or several foreign keys to the same table, or cross-reference fkey
 				$relCol .= $localColumn->getPhpName();
 			}


### PR DESCRIPTION
Well, I am not sure this is the best fix, still works for me. There sure was a problem after I migrated from Propel 1.4
First of all I cannot see a reason for table_name and foreign_table_name can ever be the same. They must be different tables after all right?
What we need to check is maybe to make sure adding relatedby string when column name matches foreign table name.
