### PR TITLE
Migration issue with empty SQL generated when foreign key has skipSql

### DIFF
--- a/generator/lib/model/diff/PropelTableComparator.php
+++ b/generator/lib/model/diff/PropelTableComparator.php
@@ -296,13 +296,17 @@ class PropelTableComparator
 		}
 
 		foreach ($fromTableFks as $fromTableFkPos => $fromTableFk) {
-			$this->tableDiff->addRemovedFk($fromTableFk->getName(), $fromTableFk);
-			$fkDifferences++;
+			if (!$fromTableFk->isSkipSql() && !in_array($fromTableFk, $toTableFks)) {
+				$this->tableDiff->addRemovedFk($fromTableFk->getName(), $fromTableFk);
+				$fkDifferences++;
+			}
 		}
 
 		foreach ($toTableFks as $toTableFkPos => $toTableFk) {
-			$this->tableDiff->addAddedFk($toTableFk->getName(), $toTableFk);
-			$fkDifferences++;
+			if (!$toTableFk->isSkipSql() && !in_array($toTableFk, $fromTableFks)) {
+				$this->tableDiff->addAddedFk($toTableFk->getName(), $toTableFk);
+				$fkDifferences++;
+			}
 		}
 
 		return $fkDifferences;

--- a/test/testsuite/generator/platform/PgsqlPlatformMigrationTest.php
+++ b/test/testsuite/generator/platform/PgsqlPlatformMigrationTest.php
@@ -374,5 +374,21 @@ ALTER TABLE "test" ALTER COLUMN "test" DROP DEFAULT;
 EOF;
 	    $this->assertEquals($expected, $this->getPlatform()->getModifyColumnDDL($columnDiffs));
 	}
-	
+
+	/**
+	 * @dataProvider providerForTestGetModifyTableForeignKeysSkipSql3DDL
+	 */
+	public function testGetModifyTableForeignKeysSkipSql3DDL($databaseDiff)
+	{
+		$this->assertFalse($databaseDiff);
+	}
+
+	/**
+	 * @dataProvider providerForTestGetModifyTableForeignKeysSkipSql4DDL
+	 */
+	public function testGetModifyTableForeignKeysSkipSql4DDL($databaseDiff)
+	{
+		$this->assertFalse($databaseDiff);
+	}
+
 }

--- a/test/testsuite/generator/platform/PlatformMigrationTestProvider.php
+++ b/test/testsuite/generator/platform/PlatformMigrationTestProvider.php
@@ -473,4 +473,70 @@ EOF;
 	    return array(array(PropelColumnComparator::computeDiff($c1, $c2)));
 	}
 
+	public function providerForTestGetModifyTableForeignKeysSkipSql3DDL()
+	{
+		$schema1 = <<<EOF
+<database name="test">
+	<table name="test">
+		<column name="test" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+		<column name="ref_test" type="INTEGER"/>
+		<foreign-key foreignTable="test2" onDelete="CASCADE" onUpdate="CASCADE" skipSql="true">
+		    <reference local="ref_test" foreign="test" />
+	    </foreign-key>
+	</table>
+	<table name="test2">
+		<column name="test" type="integer" primaryKey="true" />
+	</table>
+</database>
+EOF;
+		$schema2 = <<<EOF
+<database name="test">
+  <table name="test">
+    <column name="test" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+    <column name="ref_test" type="INTEGER"/>
+  </table>
+  <table name="test2">
+    <column name="test" type="integer" primaryKey="true" />
+  </table>
+</database>
+EOF;
+		$d1 = $this->getDatabaseFromSchema($schema1);
+		$d2 = $this->getDatabaseFromSchema($schema2);
+		$diff = PropelDatabaseComparator::computeDiff($d1, $d2);
+		return array(array($diff));
+	}
+
+	public function providerForTestGetModifyTableForeignKeysSkipSql4DDL()
+	{
+		$schema1 = <<<EOF
+<database name="test">
+	<table name="test">
+		<column name="test" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+		<column name="ref_test" type="INTEGER"/>
+		<foreign-key foreignTable="test2" onDelete="CASCADE" onUpdate="CASCADE" skipSql="true">
+		    <reference local="ref_test" foreign="test" />
+	    </foreign-key>
+	</table>
+	<table name="test2">
+		<column name="test" type="integer" primaryKey="true" />
+	</table>
+</database>
+EOF;
+		$schema2 = <<<EOF
+<database name="test">
+  <table name="test">
+    <column name="test" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+    <column name="ref_test" type="INTEGER"/>
+  </table>
+  <table name="test2">
+    <column name="test" type="integer" primaryKey="true" />
+  </table>
+</database>
+EOF;
+		$d1 = $this->getDatabaseFromSchema($schema1);
+		$d2 = $this->getDatabaseFromSchema($schema2);
+		$diff = PropelDatabaseComparator::computeDiff($d2, $d1);
+		return array(array($diff));
+	}
+
 }


### PR DESCRIPTION
There's a problem with how the migration task handles tables that have foreign keys with skipSql set to true.

If we have a schema like

``` xml
<database name="test">
  <table name="test">
    <column name="test" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
    <column name="ref_test" type="INTEGER"/>
    <foreign-key foreignTable="test2" onDelete="CASCADE" onUpdate="CASCADE" skipSql="true">
      <reference local="ref_test" foreign="test" />
    </foreign-key>
  </table>
  <table name="test2">
    <column name="test" type="integer" primaryKey="true" />
  </table>
</database>
```

and a similar structure in the database (minus the foreign key of course) and run the diff task, it will generate a migration file with the following content:

```
    public function getUpSQL()
    {
        return array (
  'test' => '',
);
    }
```

`PropelTableComparator` does not properly take into account foreign keys that have skipSql set. The `$fromTableFks`-array contains all the keys that are in the database (in the above case: none), and the `$toTableFks` the keys that are in the schema file (in the above case, one). This means it doesn't run through `PropelForeignKeyComparator` (which is ok), but then does not check for skipSql when adding the foreign keys, so it's left in the `$toTableFks`-array, and is consequently considered to be a new foreign key and added to the table diff. This means that `PropelDatabaseComparator` believes there are changes, which causes `PropelSQLDiff` to call `$platform->getModifyDatabaseDDL()`. That, in turn, calls `getModifyTableDDL()` which sets a `$ret`-variable to an empty string. When `getModifyTableDDL()`  calls `getAddForeignKeyDDL()` it notices that the foreign key has skipSql set, so it promptly returns, causing the empty string to be returned all the way back to `PropelSQLDiff` which tries to generate the migration sql with it.

The patch is fairly simple and works regardless of which way the tables are passed to it (eg. from the database as first parameter and from the schema file as the second parameter or vice versa). What it does is simply make sure that the foreign key does not have skipSql set, and if we are adding the foreign key, make sure that it does not exist in the target table. The same thing holds true for removing foreign keys, otherwise we would miss cases where the foreign key has been concrete but replaced with a skipSql-one.
