### PR TITLE
Fixed version column needs to be required for mssql.

### DIFF
--- a/generator/lib/behavior/versionable/VersionableBehavior.php
+++ b/generator/lib/behavior/versionable/VersionableBehavior.php
@@ -130,7 +130,9 @@ class VersionableBehavior extends Behavior
 			$versionTable->addForeignKey($fk);
 
 			// add the version column to the primary key
-			$versionTable->getColumn($this->getParameter('version_column'))->setPrimaryKey(true);
+			$versionColumn = $versionTable->getColumn($this->getParameter('version_column'));
+			$versionColumn->setNotNull(true);
+			$versionColumn->setPrimaryKey(true);
 			$this->versionTable = $versionTable;
 		} else {
 			$this->versionTable = $database->getTable($versionTableName);

--- a/test/testsuite/generator/behavior/versionable/VersionableBehaviorTest.php
+++ b/test/testsuite/generator/behavior/versionable/VersionableBehaviorTest.php
@@ -182,7 +182,7 @@ CREATE TABLE [versionable_behavior_test_0_version]
 	[id] INTEGER NOT NULL,
 	[bar] INTEGER,
 	[foreign_id] INTEGER,
-	[version] INTEGER DEFAULT 0,
+	[version] INTEGER DEFAULT 0 NOT NULL,
 	[foreign_id_version] INTEGER DEFAULT 0,
 	PRIMARY KEY ([id],[version])
 );
@@ -227,7 +227,7 @@ CREATE TABLE [versionable_behavior_test_1_version]
 (
 	[id] INTEGER NOT NULL,
 	[bar] INTEGER,
-	[version] INTEGER DEFAULT 0,
+	[version] INTEGER DEFAULT 0 NOT NULL,
 	[versionable_behavior_test_0_ids] MEDIUMTEXT,
 	[versionable_behavior_test_0_versions] MEDIUMTEXT,
 	PRIMARY KEY ([id],[version])
@@ -257,7 +257,7 @@ CREATE TABLE [versionable_behavior_test_0_version]
 (
 	[id] INTEGER NOT NULL,
 	[bar] INTEGER,
-	[version] INTEGER DEFAULT 0,
+	[version] INTEGER DEFAULT 0 NOT NULL,
 	PRIMARY KEY ([id],[version])
 );
 
@@ -293,7 +293,7 @@ CREATE TABLE [foo_ver]
 (
 	[id] INTEGER NOT NULL,
 	[bar] INTEGER,
-	[version] INTEGER DEFAULT 0,
+	[version] INTEGER DEFAULT 0 NOT NULL,
 	PRIMARY KEY ([id],[version])
 );
 
@@ -414,7 +414,7 @@ CREATE TABLE [versionable_behavior_test_0_version]
 (
 	[id] INTEGER NOT NULL,
 	[bar] INTEGER,
-	[version] INTEGER DEFAULT 0,
+	[version] INTEGER DEFAULT 0 NOT NULL,
 	[version_created_at] TIMESTAMP,
 	[version_created_by] VARCHAR(100),
 	[version_comment] VARCHAR(255),


### PR DESCRIPTION
The `versionable` behavior adds the version table by copying the main table, which already contains the version column.
The problem is, as the version column becomes part of the PK of the version table, it must be required.
Only MSSQL seems to complay about this, but it must be fixed anyway.

Related to https://github.com/propelorm/sfPropelORMPlugin/issues/73
