### PR TITLE
Fixed failing unit tests complaining about an "Undefined index: datasourc

### DIFF
--- a/generator/lib/util/PropelQuickBuilder.php
+++ b/generator/lib/util/PropelQuickBuilder.php
@@ -89,7 +89,7 @@ class PropelQuickBuilder
 		$this->buildClasses();
 		$name = $this->getDatabase()->getName();
 		if (!Propel::isInit()) {
-			Propel::setConfiguration(array());
+			Propel::setConfiguration(array('datasources' => array('default' => $name)));
 		}
 		Propel::setDB($name, $adapter);
 		Propel::setConnection($name, $con, Propel::CONNECTION_READ);


### PR DESCRIPTION
Fixed failing unit tests complaining about an "Undefined index: datasources" when running some tests individually
