### PR TITLE
Suggestion on how to overcome problems in #86

### DIFF
--- a/generator/lib/model/Index.php
+++ b/generator/lib/model/Index.php
@@ -114,7 +114,7 @@ class Index extends XMLElement
 				// still no name
 			}
 		}
-		if ($database = $this->getTable()->getDatabase()) {
+		if (($database = $this->getTable()->getDatabase()) && $database->getPlatform()) {
 			return substr($this->indexName, 0, $database->getPlatform()->getMaxColumnNameLength());
 		} else {
 			return $this->indexName;

--- a/generator/lib/model/Table.php
+++ b/generator/lib/model/Table.php
@@ -1034,6 +1034,13 @@ class Table extends ScopedElement implements IDMethod
 			return $unique;
 		} else {
 			$unique = new Unique($this);
+			if (!isset($unqdata['isConstraint'])) {
+				if ($this->getDatabase() && $this->getDatabase()->getPlatform()) {
+					$unqdata['isConstraint'] =
+						($this->getDatabase()->getPlatform()->supportsUniqueConstraints() ?
+							"true" : "false");
+				}
+			}
 			$unique->loadFromXML($unqdata);
 			return $this->addUnique($unique);
 		}

--- a/generator/lib/model/Unique.php
+++ b/generator/lib/model/Unique.php
@@ -25,6 +25,17 @@ require_once dirname(__FILE__) . '/Index.php';
  */
 class Unique extends Index
 {
+	private $isConstraint = false;
+
+	public function isConstraint()
+	{
+		return $this->isConstraint;
+	}
+
+	public function setIsConstraint($isConstraint)
+	{
+		$this->isConstraint = $isConstraint;
+	}
 
 	/**
 	 * Returns <code>true</code>.
@@ -32,6 +43,20 @@ class Unique extends Index
 	public function isUnique()
 	{
 		return true;
+	}
+
+	/**
+	 * Set the isConstraint flag that indicates wether this unique is a part
+	 * of a constraint or an ordinary unique index so RDBMSs can take the
+	 * appropriate steps when generating code. Defaults to false unless overridden
+	 * by the platforms.
+	 */
+	public function setupObject()
+	{
+		if (($attr = $this->getAttribute('isConstraint')) != null) {
+			$this->setIsConstraint(($attr == "true" ? true : false));
+		}
+		parent::setupObject();
 	}
 
 	/**

--- a/generator/lib/model/diff/PropelIndexComparator.php
+++ b/generator/lib/model/diff/PropelIndexComparator.php
@@ -54,6 +54,27 @@ class PropelIndexComparator
 			return true;
 		}
 
+		// Check if the platforms supports constraints and
+		// if the index has been changed to constraint or vice versa
+		if ((($ft = $fromIndex->getTable()) != null && ($fd = $ft->getDatabase()) != null &&
+		     ($fp = $fd->getPlatform()) != null) &&
+		     ($tt = $toIndex->getTable()) != null && ($td = $tt->getDatabase()) != null &&
+		     ($tp = $td->getPlatform()) != null) {
+
+			// Either the from- or to-platform does not support unique constraints,
+			// which means something has happened that has caused the platform
+			// to change, so we cannot be certain how to generate DROP or CREATE
+			// SQL - we must bail out (extremely hypothetical situation).
+			if (!$fp->supportsUniqueConstraints() || !$tp->supportsUniqueConstraints()) {
+				return false;
+			}
+
+			if ($fromIndex instanceof Unique && $toIndex instanceof Unique &&
+				$fromIndex->isConstraint() != $toIndex->isConstraint()) {
+				return true;
+			}
+		}
+
 		return false;
 	}
 

--- a/generator/lib/platform/DefaultPlatform.php
+++ b/generator/lib/platform/DefaultPlatform.php
@@ -1076,11 +1076,22 @@ ALTER TABLE %s ADD
 		return true;
 	}
 
-	
+	/**
+	 * @see	       Platform::supportsVarcharWithoutSize()
+	 */
 	public function supportsVarcharWithoutSize()
 	{
 		return false;
 	}
+
+	/**
+	 * @see        Platform::supportsUniqueConstraints();
+	 */
+	public function supportsUniqueConstraints()
+	{
+		return false;
+	}
+
 	/**
 	 * Returns the boolean value for the RDBMS.
 	 *

--- a/generator/lib/platform/PropelPlatformInterface.php
+++ b/generator/lib/platform/PropelPlatformInterface.php
@@ -184,7 +184,13 @@ interface PropelPlatformInterface
 	 * @return boolean
 	 */
 	public function supportsVarcharWithoutSize();
-	
+
+	/**
+	 * Wether uniques should be considered constraints or normal indexes
+	 * @return boolean
+	 */
+	public function supportsUniqueConstraints();
+
 	/**
 	 * Returns the boolean value for the RDBMS.
 	 *

--- a/generator/resources/xsd/database.xsd
+++ b/generator/resources/xsd/database.xsd
@@ -274,6 +274,7 @@
 			<xs:element ref="vendor" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:choice>
 		<xs:attribute name="name" type="index_name" use="optional"/>
+		<xs:attribute name="isConstraint" type="xs:boolean" default="false" use="optional"/>
 	</xs:complexType>
 
 	<xs:complexType name="index-column">

--- a/test/testsuite/generator/platform/MysqlPlatformMigrationTest.php
+++ b/test/testsuite/generator/platform/MysqlPlatformMigrationTest.php
@@ -281,4 +281,13 @@ ALTER TABLE `foo` ADD
 ";
 		$this->assertEquals($expected, $this->getPlatform()->getAddColumnsDDL($columns));
 	}
+
+	/**
+	 * @dataProvider providerForTestGetModifyUniqueConstraintDDL
+	 */
+	public function testGetModifyUniqueConstraintDDL($tableDiff)
+	{
+		$this->assertFalse($tableDiff);
+	}
+	
 }

--- a/test/testsuite/generator/platform/PgsqlPlatformMigrationTest.php
+++ b/test/testsuite/generator/platform/PgsqlPlatformMigrationTest.php
@@ -333,7 +333,7 @@ EOF;
 		$this->assertSame($expected, $columnDiff);
 	}
 
-public function testGetModifyColumnDDLWithVarcharWithoutSizeAndPlatform()
+	public function testGetModifyColumnDDLWithVarcharWithoutSizeAndPlatform()
 	{
 		$t1 = new Table('foo');
 		$c1 = new Column('bar');
@@ -389,6 +389,61 @@ EOF;
 	public function testGetModifyTableForeignKeysSkipSql4DDL($databaseDiff)
 	{
 		$this->assertFalse($databaseDiff);
+	}
+
+	/**
+	 * @dataProvider providerForTestGetModifyUniqueConstraintDDL
+	 */
+	public function testGetModifyUniqueConstraintDDL($tableDiff)
+	{
+		$expected1 = "
+DROP INDEX \"test_U_1\";
+
+ALTER TABLE \"test\" ADD CONSTRAINT \"test_U_1\" UNIQUE (\"test\");
+";
+		$expected2 = "
+ALTER TABLE \"test\" DROP CONSTRAINT \"test_U_1\";
+
+CREATE UNIQUE INDEX \"test_U_1\" ON \"test\" (\"test\");
+";
+		$this->assertEquals($this->getPlatform()->getModifyTableDDL($tableDiff), $expected1);
+		$this->assertEquals($this->getPlatform()->getModifyTableDDL($tableDiff->getReverseDiff()), $expected2);
+	}
+
+	/**
+	 * @dataProvider providerForTestGetModifyUniqueConstraintWithSchemaDDL
+	 */
+	public function testGetModifyUniqueConstraintWithSchemaDDL($tableDiff)
+	{
+		$expected1 = "
+DROP INDEX \"test\".\"test_U_1\";
+
+ALTER TABLE \"test\".\"test\" ADD CONSTRAINT \"test_U_1\" UNIQUE (\"test\");
+";
+		$expected2 = "
+ALTER TABLE \"test\".\"test\" DROP CONSTRAINT \"test_U_1\";
+
+CREATE UNIQUE INDEX \"test_U_1\" ON \"test\".\"test\" (\"test\");
+";
+		$this->assertEquals($expected1, $this->getPlatform()->getModifyTableDDL($tableDiff));
+		$this->assertEquals($expected2, $this->getPlatform()->getModifyTableDDL($tableDiff->getReverseDiff()));
+	}
+
+	/**
+	 * @dataProvider providerForTestGetModifyUniqueConstraintWithSameColumnWithoutPlatformDDL
+	 */
+
+	public function testGetModifyUniqueConstraintWithSameColumnWithoutPlatformDDL($tableDiff)
+	{
+		$this->assertFalse($tableDiff);
+	}
+
+	/**
+	 * @dataProvider providerForTestGetModifyUniqueConstraintWithSameColumnAndTargetPlatformNotSupportingConstraintsDDL
+	 */
+	public function testGetModifyUniqueConstraintWithSameColumnAndTargetPlatformNotSupportingConstraintsDDL($tableDiff)
+	{
+		$this->assertFalse($tableDiff);
 	}
 
 }

--- a/test/testsuite/generator/platform/PgsqlPlatformTest.php
+++ b/test/testsuite/generator/platform/PgsqlPlatformTest.php
@@ -316,6 +316,26 @@ CREATE TABLE "foo"
 (
 	"id" serial NOT NULL,
 	"bar" INTEGER,
+	PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "foo_U_1" ON "foo" ("bar");
+
+EOF;
+		$this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+	}
+	/**
+	 * @dataProvider providerForTestGetAddTableDDLUniqueConstraint
+	 */
+	public function testGetAddTableDDLUniqueConstraint($schema)
+	{
+		$table = $this->getTableFromSchema($schema);
+		$expected = <<<EOF
+
+CREATE TABLE "foo"
+(
+	"id" serial NOT NULL,
+	"bar" INTEGER,
 	PRIMARY KEY ("id"),
 	CONSTRAINT "foo_U_1" UNIQUE ("bar")
 );
@@ -605,7 +625,18 @@ CREATE INDEX \"foo_index\" ON \"foo\" (\"bar1\");
 		$expected = "
 DROP INDEX \"babar\";
 ";
-		$this->assertEquals($expected, $this->getPLatform()->getDropIndexDDL($index));
+		$this->assertEquals($expected, $this->getPlatform()->getDropIndexDDL($index));
+	}
+
+	/**
+	 * @dataProvider providerForTestGetDropIndexWithSchemaDDL
+	 */
+	public function testDropIndexWithSchemaDDL($index)
+	{
+		$expected ="
+DROP INDEX \"test\".\"bar\";
+";
+		$this->assertEquals($expected, $this->getPlatform()->getDropIndexDDL($index));
 	}
 
 	/**
@@ -624,6 +655,17 @@ DROP INDEX \"babar\";
 	{
 		$expected = 'CONSTRAINT "babar" UNIQUE ("bar1","bar2")';
 		$this->assertEquals($expected, $this->getPlatform()->getUniqueDDL($index));
+	}
+
+	/**
+	 * @dataProvider providerForTestGetUniqueIndexDDL
+	 */
+	public function testGetUniqueIndexDDL($index)
+	{
+		$expected = '
+CREATE UNIQUE INDEX "babar" ON "foo" ("bar1","bar2");
+';
+		$this->assertEquals($expected, $this->getPlatform()->getAddIndexDDL($index));
 	}
 
 	/**

--- a/test/testsuite/generator/platform/PlatformMigrationTestProvider.php
+++ b/test/testsuite/generator/platform/PlatformMigrationTestProvider.php
@@ -539,4 +539,136 @@ EOF;
 		return array(array($diff));
 	}
 
+	public function providerForTestGetModifyUniqueConstraintDDL()
+	{
+		$schema1 = <<<EOF
+<database name="test">
+  <table name="test">
+    <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+	<column name="test" type="INTEGER" />
+	<unique isConstraint="false">
+	  <unique-column name="test" />
+	</unique>
+  </table>
+</database>
+EOF;
+		$schema2 = <<<EOF
+<database name="test">
+  <table name="test">
+    <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+	<column name="test" type="INTEGER" />
+	<unique>
+	  <unique-column name="test" />
+	</unique>
+  </table>
+</database>
+EOF;
+		$t1 = $this->getDatabaseFromSchema($schema1)->getTable('test');
+		$t2 = $this->getDatabaseFromSchema($schema2)->getTable('test');
+		$diff = PropelTableComparator::computeDiff($t1, $t2);
+		return array(array($diff));
+	}
+
+	public function providerForTestGetModifyUniqueConstraintWithSchemaDDL()
+	{
+		$schema1 = <<<EOF
+<database name="test">
+  <table name="test" schema="test">
+    <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+	<column name="test" type="INTEGER" />
+	<unique isConstraint="false">
+	  <unique-column name="test" />
+	</unique>
+  </table>
+</database>
+EOF;
+		$schema2 = <<<EOF
+<database name="test">
+  <table name="test" schema="test">
+    <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+	<column name="test" type="INTEGER" />
+	<unique>
+	  <unique-column name="test" />
+	</unique>
+  </table>
+</database>
+EOF;
+		$t1 = $this->getDatabaseFromSchema($schema1)->getTable('test.test');
+		$t2 = $this->getDatabaseFromSchema($schema2)->getTable('test.test');
+		$diff = PropelTableComparator::computeDiff($t1, $t2);
+		return array(array($diff));
+	}
+
+	public function providerForTestGetModifyUniqueConstraintWithSameColumnWithoutPlatformDDL()
+	{
+		$schema1 = <<<EOF
+<database name="test">
+  <table name="test">
+    <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+	<column name="test" type="INTEGER" />
+	<unique isConstraint="false" name="test_U_1">
+	  <unique-column name="test" />
+	</unique>
+  </table>
+</database>
+EOF;
+		$schema2 = <<<EOF
+<database name="test">
+  <table name="test">
+    <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+	<column name="test" type="INTEGER" />
+	<unique name="test_U_1">
+	  <unique-column name="test" />
+	</unique>
+  </table>
+</database>
+EOF;
+		$xtad1 = new XmlToAppData(null);
+		$appData = $xtad1->parseString($schema1);
+		$db1 = $appData->getDatabase();
+		$table1 = $db1->getTable('test');
+		$xtad2 = new XmlToAppData(null);
+		$appData = $xtad2->parseString($schema2);
+		$db2 = $appData->getDatabase();
+		$table2 = $db2->getTable('test');
+		$diff = PropelTableComparator::computeDiff($table1, $table2);
+		return array(array($diff));
+	}
+
+	public function providerForTestGetModifyUniqueConstraintWithSameColumnAndTargetPlatformNotSupportingConstraintsDDL()
+	{
+		$schema1 = <<<EOF
+<database name="test">
+  <table name="test">
+    <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+	<column name="test" type="INTEGER" />
+	<unique isConstraint="false" name="test_U_1">
+	  <unique-column name="test" />
+	</unique>
+  </table>
+</database>
+EOF;
+		$schema2 = <<<EOF
+<database name="test">
+  <table name="test">
+    <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true" />
+	<column name="test" type="INTEGER" />
+	<unique name="test_U_1">
+	  <unique-column name="test" />
+	</unique>
+  </table>
+</database>
+EOF;
+		$xtad1 = new XmlToAppData(new PgsqlPlatform());
+		$appData = $xtad1->parseString($schema1);
+		$db1 = $appData->getDatabase();
+		$table1 = $db1->getTable('test');
+		$xtad2 = new XmlToAppData(new DefaultPlatform());
+		$appData = $xtad2->parseString($schema2);
+		$db2 = $appData->getDatabase();
+		$table2 = $db2->getTable('test');
+		$diff = PropelTableComparator::computeDiff($table1, $table2);
+		return array(array($diff));
+	}
+
 }

--- a/test/testsuite/generator/platform/PlatformTestProvider.php
+++ b/test/testsuite/generator/platform/PlatformTestProvider.php
@@ -134,6 +134,22 @@ EOF;
 	<table name="foo">
 		<column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
 		<column name="bar" type="INTEGER" />
+		<unique isConstraint="false">
+			<unique-column name="bar" />
+		</unique>
+	</table>
+</database>
+EOF;
+		return array(array($schema));
+	}
+
+	public function providerForTestGetAddTableDDLUniqueConstraint()
+	{
+		$schema = <<<EOF
+<database name="test">
+	<table name="foo">
+		<column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
+		<column name="bar" type="INTEGER" />
 		<unique>
 			<unique-column name="bar" />
 		</unique>
@@ -167,6 +183,46 @@ EOF;
 		$column2->getDomain()->copy(new Domain('BARTYPE'));
 		$table->addColumn($column2);
 		$index = new Unique('babar');
+		$index->setIsConstraint(true);
+		$index->addColumn($column1);
+		$index->addColumn($column2);
+		$table->addUnique($index);
+
+		return array(
+			array($index)
+		);
+	}
+
+	public function providerForTestGetUniqueIndexDDL()
+	{
+		$table = new Table('foo');
+		$column1 = new Column('bar1');
+		$column1->getDomain()->copy(new Domain('FOOTYPE'));
+		$table->addColumn($column1);
+		$column2 = new Column('bar2');
+		$column2->getDomain()->copy(new Domain('BARTYPE'));
+		$table->addColumn($column2);
+		$index = new Unique('babar');
+		$index->addColumn($column1);
+		$index->addColumn($column2);
+		$table->addUnique($index);
+
+		return array(
+			array($index)
+		);
+	}
+
+	public function providerForTestGetUniqueConstraintDDL()
+	{
+		$table = new Table('foo');
+		$column1 = new Column('bar1');
+		$column1->getDomain()->copy(new Domain('FOOTYPE'));
+		$table->addColumn($column1);
+		$column2 = new Column('bar2');
+		$column2->getDomain()->copy(new Domain('BARTYPE'));
+		$table->addColumn($column2);
+		$index = new Unique('babar');
+		$index->setIsConstraint(true);
 		$index->addColumn($column1);
 		$index->addColumn($column2);
 		$table->addUnique($index);
@@ -210,6 +266,21 @@ EOF;
 		$index = new Index('babar');
 		$index->addColumn($column1);
 		$index->addColumn($column2);
+		$table->addIndex($index);
+
+		return array(
+			array($index)
+		);
+	}
+
+	public function providerForTestGetDropIndexWithSchemaDDL()
+	{
+		$table = new Table('foo');
+		$table->setSchema('test');
+		$column1 = new Column('bar1');
+		$column1->getDomain()->copy(new Domain('FOOTYPE'));
+		$table->addColumn($column1);
+		$index = new Index('bar');
 		$table->addIndex($index);
 
 		return array(


### PR DESCRIPTION
- Adds isConstraint-attribute to the <unique>-element, defaults to false
- Adds isConstraint-method to Unique, defaults to false
- DefaultPlatform defaults to "does not support constraints"
- PsqlPlatform overrides that setting
- PsqlSchemaParser properly detects if an index is just an index or if it's a part of a unique constraint
- PropelIndexComparator checks that both (From- and ToPlatform) supports constraints before checking if they have changed
- Does not in any way alter how other platforms work so people who know the other platforms can implement this properly for those platforms if needed
