### PR TITLE
the semicolons are missing between sql request in $statementsToInsert

### DIFF
--- a/generator/lib/util/PropelSqlManager.php
+++ b/generator/lib/util/PropelSqlManager.php
@@ -221,8 +221,7 @@ class PropelSqlManager
 			$pdo->beginTransaction();
 
 			try {
-				foreach ($sqls as $sql)
-				{
+				foreach ($sqls as $sql) {
 					$stmt = $pdo->prepare($sql);
 					$stmt->execute();	
 				}


### PR DESCRIPTION
when i used "app/console propel:build --sql --insert-sql"

i get this exception 

"exception 'PDOException' with message 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax" in vendor/propel/generator/lib/util/PropelSqlManager.php
