### PR TITLE
Fix leaking transaction in save.

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -2502,7 +2502,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 		}
 
 		$script .= "
-		} catch (PropelException \$e) {
+		} catch (Exception \$e) {
 			\$con->rollBack();
 			throw \$e;
 		}";
@@ -4385,7 +4385,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 		}
 
 		$script .= "
-		} catch (PropelException \$e) {
+		} catch (Exception \$e) {
 			\$con->rollBack();
 			throw \$e;
 		}";


### PR DESCRIPTION
Fix bug that would cause a transaction to leak if an Exception that isn't PropelException is thrown during preSave, preInsert, preUpdate, doSave, postInsert, postUpdate, postSave.
