### PR TITLE
Implemented One-To-Many setters.

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -229,10 +229,16 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 		}
 
 		if ($table->hasCrossForeignKeys()) {
-			foreach ($this->getTable()->getCrossFks() as $fkList) {
+			foreach ($table->getCrossFks() as $fkList) {
 				list($refFK, $crossFK) = $fkList;
-				$this->addScheduledForDeletionAttribute($script, $refFK, $crossFK);
+				$fkName = $this->getFKPhpNameAffix($crossFK, $plural = true);
+				$this->addScheduledForDeletionAttribute($script, $fkName);
 			}
+		}
+
+		foreach ($table->getReferrers() as $refFK) {
+			$fkName = $this->getRefFKPhpNameAffix($refFK, $plural = true);
+			$this->addScheduledForDeletionAttribute($script, $fkName);
 		}
 
 		if ($this->hasDefaultValues()) {
@@ -3312,8 +3318,10 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 				$this->addRefFKClear($script, $refFK);
 				$this->addRefFKInit($script, $refFK);
 				$this->addRefFKGet($script, $refFK);
+				$this->addRefFKSet($script, $refFK);
 				$this->addRefFKCount($script, $refFK);
 				$this->addRefFKAdd($script, $refFK);
+				$this->addRefFKDoAdd($script, $refFK);
 				$this->addRefFKGetJoinMethods($script, $refFK);
 			}
 		}
@@ -3434,8 +3442,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 			\$this->init".$this->getRefFKPhpNameAffix($refFK, $plural = true)."();
 		}
 		if (!\$this->{$collName}->contains(\$l)) { // only add it if the **same** object is not already associated
-			\$this->{$collName}[]= \$l;
-			\$l->set".$this->getFKPhpNameAffix($refFK, $plural = false)."(\$this);
+			\$this->doAdd" . $this->getRefFKPhpNameAffix($refFK, $plural = false)  . "(\$l);
 		}
 
 		return \$this;
@@ -3546,6 +3553,75 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 ";
 	} // addRefererGet()
 
+	protected function addRefFKSet(&$script, $refFK)
+	{
+		$relatedName = $this->getRefFKPhpNameAffix($refFK, $plural = true);
+		$relatedObjectClassName = $this->getRefFKPhpNameAffix($refFK, $plural = false);
+
+		// No lcfirst() in PHP < 5.3
+		$inputCollection = $relatedName;
+		$inputCollection[0] = strtolower($inputCollection[0]);
+
+		// No lcfirst() in PHP < 5.3
+		$inputCollectionEntry = $this->getRefFKPhpNameAffix($refFK, $plural = false);
+		$inputCollectionEntry[0] = strtolower($inputCollectionEntry[0]);
+
+		$collName = $this->getRefFKCollVarName($refFK);
+
+		$script .= "
+	/**
+	 * Sets a collection of $relatedObjectClassName objects related by a one-to-many relationship
+	 * to the current object.
+	 * It will also schedule objects for deletion based on a diff between old objects (aka persisted)
+	 * and new objects from the given Propel collection.
+	 *
+	 * @param      PropelCollection \${$inputCollection} A Propel collection.
+	 * @param      PropelPDO \$con Optional connection object
+	 */
+	public function set{$relatedName}(PropelCollection \${$inputCollection}, PropelPDO \$con = null)
+	{
+		\$this->{$inputCollection}ScheduledForDeletion = \$this->get{$relatedName}(new Criteria(), \$con)->diff(\${$inputCollection});
+
+		foreach (\${$inputCollection} as \${$inputCollectionEntry}) {
+			// Fix issue with collection modified by reference
+			if (\${$inputCollectionEntry}->isNew()) {
+				\${$inputCollectionEntry}->set" . $this->getFKPhpNameAffix($refFK, $plural = false)."(\$this);
+			}
+			\$this->add{$relatedObjectClassName}(\${$inputCollectionEntry});
+		}
+
+		\$this->{$collName} = \${$inputCollection};
+	}
+";
+	}
+
+	/**
+	 * @param		string &$script The script will be modified in this method.
+	 * @param		ForeignKey $refFK
+	 * @param		ForeignKey $crossFK
+	 */
+	protected function addRefFKDoAdd(&$script, $refFK)
+	{
+		$relatedObjectClassName = $this->getRefFKPhpNameAffix($refFK, $plural = false);
+
+		// lcfirst() doesn't exist in PHP < 5.3
+		$lowerRelatedObjectClassName = $relatedObjectClassName;
+		$lowerRelatedObjectClassName[0] = strtolower($lowerRelatedObjectClassName[0]);
+
+		$collName = $this->getRefFKCollVarName($refFK);
+
+		$script .= "
+	/**
+	 * @param	{$relatedObjectClassName} \${$lowerRelatedObjectClassName} The $lowerRelatedObjectClassName object to add.
+	 */
+	protected function doAdd{$relatedObjectClassName}(\${$lowerRelatedObjectClassName})
+	{
+		\$this->{$collName}[]= \${$lowerRelatedObjectClassName};
+		\${$lowerRelatedObjectClassName}->set" . $this->getFKPhpNameAffix($refFK, $plural = false)."(\$this);
+	}
+";
+	}
+
 	/**
 	 * Adds the method that gets a one-to-one related referrer fkey.
 	 * This is for one-to-one relationship special case.
@@ -3634,22 +3710,21 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 ";
 	}
 
-	protected function addScheduledForDeletionAttribute(&$script, $refFK, $crossFK)
+	protected function addScheduledForDeletionAttribute(&$script, $fkName)
 	{
 		// No lcfirst() in PHP < 5.3
-		$relatedName = $this->getFKPhpNameAffix($crossFK, $plural = true);
-		$relatedName[0] = strtolower($relatedName[0]);
+		$fkName[0] = strtolower($fkName[0]);
 
 		$script .= "
 	/**
 	 * An array of objects scheduled for deletion.
 	 * @var		array
 	 */
-	protected \${$relatedName}ScheduledForDeletion = null;
+	protected \${$fkName}ScheduledForDeletion = null;
 ";
 	}
 
-	protected function addScheduledForDeletionCode(&$script, $refFK, $crossFK)
+	protected function addCrossFkScheduledForDeletion(&$script, $refFK, $crossFK)
 	{
 		$queryClassName = $this->getRefFKPhpNameAffix($refFK, $plural = false) . 'Query';
 		$relatedName = $this->getFKPhpNameAffix($crossFK, $plural = true);
@@ -3673,6 +3748,31 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 					if (\${$lowerSingleRelatedName}->isModified()) {
 						\${$lowerSingleRelatedName}->save(\$con);
 					}
+				}
+			}
+";
+	}
+
+	protected function addRefFkScheduledForDeletion(&$script, $refFK)
+	{
+		$relatedName = $this->getRefFKPhpNameAffix($refFK, $plural = true);
+
+		// No lcfirst() in PHP < 5.3
+		$lowerRelatedName = $relatedName;
+		$lowerRelatedName[0] = strtolower($lowerRelatedName[0]);
+		// No lcfirst() in PHP < 5.3
+		$lowerSingleRelatedName = $this->getRefFKPhpNameAffix($refFK, $plural = false);
+		$lowerSingleRelatedName[0] = strtolower($lowerSingleRelatedName[0]);
+
+		$queryClassName = $this->getNewStubQueryBuilder($refFK->getTable())->getClassname();
+
+		$script .= "
+			if (\$this->{$lowerRelatedName}ScheduledForDeletion !== null) {
+				if (!\$this->{$lowerRelatedName}ScheduledForDeletion->isEmpty()) {
+					$queryClassName::create()
+						->filterByPrimaryKeys(\$this->{$lowerRelatedName}ScheduledForDeletion->getPrimaryKeys(false))
+						->delete(\$con);
+					\$this->{$lowerRelatedName}ScheduledForDeletion = null;
 				}
 			}
 ";
@@ -4145,13 +4245,14 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 ";
 
 		if ($table->hasCrossForeignKeys()) {
-			foreach ($this->getTable()->getCrossFks() as $fkList) {
+			foreach ($table->getCrossFks() as $fkList) {
 				list($refFK, $crossFK) = $fkList;
-				$this->addScheduledForDeletionCode($script, $refFK, $crossFK);
+				$this->addCrossFkScheduledForDeletion($script, $refFK, $crossFK);
 			}
 		}
 
 		foreach ($table->getReferrers() as $refFK) {
+			$this->addRefFkScheduledForDeletion($script, $refFK);
 
 			if ($refFK->isLocalPrimaryKey()) {
 				$varName = $this->getPKRefFKVarName($refFK);

--- a/test/testsuite/generator/builder/om/GeneratedObjectTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectTest.php
@@ -1335,4 +1335,243 @@ EOF;
         $cv = new ContestView();
         $this->assertFalse(method_exists($cv, $method), 'readOnly tables end up with no ' . $method . ' method in the generated object class');
     }
+
+	public function testSetterOneToMany()
+	{
+		// Ensure no data
+		BookQuery::create()->deleteAll();
+		AuthorQuery::create()->deleteAll();
+
+		$coll = new PropelObjectCollection();
+		$coll->setModel('Book');
+
+		for ($i = 0; $i < 3; $i++) {
+			$coll[] = new Book();
+		}
+
+		$this->assertEquals(3, $coll->count());
+
+		$a = new Author();
+		$a->setBooks($coll);
+		$a->save();
+
+		$this->assertInstanceOf('PropelObjectCollection', $a->getBooks());
+		$this->assertEquals(3, $a->getBooks()->count());
+		$this->assertEquals(1, AuthorQuery::create()->count());
+		$this->assertEquals(3, BookQuery::create()->count());
+
+		$coll->shift();
+		$this->assertEquals(2, $coll->count());
+
+		$a->setBooks($coll);
+		$a->save();
+
+		$this->assertEquals(2, $a->getBooks()->count());
+		$this->assertEquals(1, AuthorQuery::create()->count());
+		$this->assertEquals(2, BookQuery::create()->count());
+
+		$newBook = new Book();
+		$newBook->setTitle('My New Book');
+		$newBook->setIsbn(1234);
+
+		// Kind of new collection
+		$coll = clone $coll;
+		$coll[] = $newBook;
+
+		$a->setBooks($coll);
+		$a->save();
+
+		$this->assertEquals(3, $coll->count());
+		$this->assertEquals(3, $a->getBooks()->count());
+		$this->assertEquals(1, AuthorQuery::create()->count());
+		$this->assertEquals(3, BookQuery::create()->count());
+
+		// Add a new object
+		$newBook1 = new Book();
+		$newBook1->setTitle('My New Book1');
+		$newBook1->setIsbn(1256);
+
+		// Existing collection - The fix around reference is tested here.
+		$coll[] = $newBook1;
+
+		$a->setBooks($coll);
+		$a->save();
+
+		$this->assertEquals(4, $coll->count());
+		$this->assertEquals(4, $a->getBooks()->count());
+		$this->assertEquals(1, AuthorQuery::create()->count());
+		$this->assertEquals(4, BookQuery::create()->count());
+
+		// Add the same collection
+		$books = $a->getBooks();
+
+		$a->setBooks($books);
+		$a->save();
+
+		$this->assertEquals(4, $books->count());
+		$this->assertEquals(4, $a->getBooks()->count());
+		$this->assertEquals(1,  AuthorQuery::create()->count());
+		$this->assertEquals(4, BookQuery::create()->count());
+	}
+
+	public function testSetterOneToManyWithNoData()
+	{
+		// Ensure no data
+		BookQuery::create()->deleteAll();
+		AuthorQuery::create()->deleteAll();
+
+		$books = new PropelObjectCollection();
+		$this->assertEquals(0, $books->count());
+
+		// Basic usage
+		$a = new Author();
+		$a->setBooks($books);
+		$a->save();
+
+		$this->assertEquals(0, $a->getBooks()->count());
+		$this->assertEquals(1, AuthorQuery::create()->count());
+		$this->assertEquals(0, BookQuery::create()->count());
+	}
+
+	public function testSetterOneToManySavesForeignObjects()
+	{
+		// Ensure no data
+		BookQuery::create()->deleteAll();
+		AuthorQuery::create()->deleteAll();
+
+		$book = new Book();
+		$book->setTitle('My Book');
+		$book->save();
+
+		// Modify it but don't save it
+		$book->setTitle('My Title');
+
+		$coll = new PropelObjectCollection();
+		$coll[] = $book;
+
+		BookPeer::clearInstancePool();
+		$book = BookQuery::create()->findPk($book->getPrimaryKey());
+
+		$a = new Author();
+		$a->setBooks($coll);
+		$a->save();
+
+		$this->assertEquals(1, $a->getBooks()->count());
+		$this->assertEquals(1, AuthorQuery::create()->count());
+		$this->assertEquals(1, BookQuery::create()->count());
+
+		$result = BookQuery::create()
+			->filterById($book->getId())
+			->select('Title')
+			->findOne();
+		$this->assertSame('My Title', $result);
+	}
+
+	public function testSetterOneToManyWithNewObjects()
+	{
+		// Ensure no data
+		BookQuery::create()->deleteAll();
+		AuthorQuery::create()->deleteAll();
+
+		$coll = new PropelObjectCollection();
+		$coll->setModel('Book');
+
+		$coll[] = new Book();
+		$coll[] = new Book();
+		$coll[] = new Book();
+
+		$a = new Author();
+		$a->setBooks($coll);
+		$a->save();
+
+		$this->assertEquals(3, $coll->count());
+		$this->assertEquals(3, count($a->getBooks()));
+		$this->assertSame($coll, $a->getBooks());
+		$this->assertEquals(1, AuthorQuery::create()->count());
+		$this->assertEquals(3, BookQuery::create()->count());
+	}
+
+	public function testSetterOneToManyWithExistingObjects()
+	{
+		// Ensure no data
+		BookQuery::create()->deleteAll();
+		AuthorQuery::create()->deleteAll();
+
+		for ($i = 0; $i < 3; $i++) {
+			$b = new Book();
+			$b->setTitle('Book ' . $i);
+			$b->save();
+		}
+
+		BookPeer::clearInstancePool();
+		$books = BookQuery::create()->find();
+
+		$a = new Author();
+		$a->setBooks($books);
+		$a->save();
+
+		$this->assertEquals(3, count($a->getBooks()));
+		$this->assertEquals(1, AuthorQuery::create()->count());
+		$this->assertEquals(3, BookQuery::create()->count());
+
+		$i = 0;
+		foreach ($a->getBooks() as $book) {
+			$this->assertEquals('Book ' . $i++, $book->getTitle());
+		}
+	}
+
+	public function testSetterOneToManyWithEmptyCollection()
+	{
+		// Ensure no data
+		BookQuery::create()->deleteAll();
+		AuthorQuery::create()->deleteAll();
+
+		$a = new Author();
+		$a->setBooks(new PropelObjectCollection());
+		$a->save();
+
+		$this->assertEquals(0, count($a->getBooks()));
+
+		$this->assertEquals(0, BookQuery::create()->count());
+		$this->assertEquals(1, AuthorQuery::create()->count());
+	}
+
+	public function testSetterOneToManyReplacesOldObjectsByNewObjects()
+	{
+		// Ensure no data
+		BookQuery::create()->deleteAll();
+		AuthorQuery::create()->deleteAll();
+
+		$books = new PropelObjectCollection();
+		foreach (array('foo', 'bar') as $title) {
+			$b = new Book();
+			$b->setTitle($title);
+			$books[] = $b;
+		}
+
+		$a = new Author();
+		$a->setBooks($books);
+		$a->save();
+
+		$books = $a->getBooks();
+		$this->assertEquals('foo', $books[0]->getTitle());
+		$this->assertEquals('bar', $books[1]->getTitle());
+
+		$books = new PropelObjectCollection();
+		foreach (array('bam', 'bom') as $title) {
+			$b = new Book();
+			$b->setTitle($title);
+			$books[] = $b;
+		}
+
+		$a->setBooks($books);
+		$a->save();
+
+		$books = $a->getBooks();
+		$this->assertEquals('bam', $books[0]->getTitle());
+		$this->assertEquals('bom', $books[1]->getTitle());
+
+		$this->assertEquals(1, AuthorQuery::create()->count());
+		$this->assertEquals(2, BookQuery::create()->count());
+	}
 }


### PR DESCRIPTION
Allows to pass a collection of objects in a main object by using a
setter. E.g:

```
$books   = new PropelObjectCollectio();
$books[] = new Book();
$books[] = new Book();
// ...
$author->setBooks($books);
```
