### PR TITLE
Bugfix: getTable() => getArchiveTable(). A "archive_at" column only exsis

### DIFF
--- a/generator/lib/behavior/archivable/ArchivableBehavior.php
+++ b/generator/lib/behavior/archivable/ArchivableBehavior.php
@@ -131,7 +131,7 @@ class ArchivableBehavior extends Behavior
 	public function getArchivedAtColumn()
 	{
 		if ($this->getParameter('log_archived_at') == 'true') {
-			return $this->getTable()->getColumn($this->getParameter('archived_at_column'));
+			return $this->getArchiveTable()->getColumn($this->getParameter('archived_at_column'));
 		}
 	}
 


### PR DESCRIPTION
Bugfix: getTable() => getArchiveTable(). A "archive_at" column only exsist in the archive table.
