### PR TITLE
Properly define non-integer single PKs when using SQLite

### DIFF
--- a/generator/lib/platform/SqlitePlatform.php
+++ b/generator/lib/platform/SqlitePlatform.php
@@ -62,8 +62,11 @@ class SqlitePlatform extends DefaultPlatform
 			$lines[] = $this->getColumnDDL($column);
 		}
 
-		if ($table->hasPrimaryKey() && count($table->getPrimaryKey()) > 1) {
-			$lines[] = $this->getPrimaryKeyDDL($table);
+		if ($table->hasPrimaryKey()) {
+		  $pk = $table->getPrimaryKey();
+		  if (count($pk) > 1 || !$pk[0]->isAutoIncrement()) {
+		    $lines[] = $this->getPrimaryKeyDDL($table);
+		  }
 		}
 
 		foreach ($table->getUnices() as $unique) {

--- a/test/testsuite/generator/platform/PlatformTestProvider.php
+++ b/test/testsuite/generator/platform/PlatformTestProvider.php
@@ -112,6 +112,19 @@ EOF;
 EOF;
 		return array(array($schema));
 	}
+	
+	public function providerForTestGetAddTableDDLNonIntegerPK()
+	{
+		$schema = <<<EOF
+<database name="test">
+	<table name="foo" description="This is foo table">
+		<column name="foo" primaryKey="true" type="VARCHAR" />
+		<column name="bar" type="VARCHAR" size="255" required="true" />
+	</table>
+</database>
+EOF;
+		return array(array($schema));
+	}
 
 	public function providerForTestGetAddTableDDLCompositePK()
 	{

--- a/test/testsuite/generator/platform/SqlitePlatformTest.php
+++ b/test/testsuite/generator/platform/SqlitePlatformTest.php
@@ -128,6 +128,24 @@ CREATE TABLE foo
 ";
 		$this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
 	}
+	
+	/**
+	 * @dataProvider providerForTestGetAddTableDDLNonIntegerPK
+	 */
+	public function testGetAddTableDDLNonIntegerPK($schema)
+	{
+		$table = $this->getTableFromSchema($schema);
+		$expected = "
+-- This is foo table
+CREATE TABLE foo
+(
+	foo VARCHAR(255) NOT NULL,
+	bar VARCHAR(255) NOT NULL,
+	PRIMARY KEY (foo)
+);
+";
+		$this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+	}
 
 	/**
 	 * @dataProvider providerForTestGetAddTableDDLCompositePK


### PR DESCRIPTION
Non-integer single primary keys aren't defined as such in the table CREATE statement when using SQLite as a database.
