### PR TITLE
Fix magic findByXXXAndYYY finders when using related object arguments

### DIFF
--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -242,7 +242,7 @@ class ModelCriteria extends Criteria
 	public function filterByArray($conditions)
 	{
 		foreach ($conditions as $column => $args) {
-			call_user_func_array(array($this, 'filterBy' . $column), (array) $args);
+			call_user_func(array($this, 'filterBy' . $column), $args);
 		}
 
 		return $this;

--- a/test/testsuite/runtime/query/ModelCriteriaTest.php
+++ b/test/testsuite/runtime/query/ModelCriteriaTest.php
@@ -2033,6 +2033,19 @@ class ModelCriteriaTest extends BookstoreTestBase
 		$expectedSQL = "SELECT book.ID, book.TITLE, book.ISBN, book.PRICE, book.PUBLISHER_ID, book.AUTHOR_ID FROM `book` WHERE book.TITLE='Don Juan' AND book.ISBN=1234 LIMIT 1";
 		$this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'findOneByXXX($value) is turned into findOneBy(XXX, $value)');
 	}
+	
+	public function testMagicFindByObject()
+	{
+		$con = Propel::getConnection(BookPeer::DATABASE_NAME);
+
+		$c = new ModelCriteria('bookstore', 'Author');
+		$testAuthor = $c->findOne();
+
+		$q = BookQuery::create()
+			->findByAuthorAndISBN($testAuthor, 1234);
+		$expectedSQL = "SELECT book.ID, book.TITLE, book.ISBN, book.PRICE, book.PUBLISHER_ID, book.AUTHOR_ID FROM `book` WHERE book.AUTHOR_ID=" . $testAuthor->getId() . " AND book.ISBN=1234";
+		$this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'findByXXXAndYYY($value) is turned into findBy(array(XXX, YYY), $value)');
+	}
 
 	public function testMagicFilterBy()
 	{


### PR DESCRIPTION
When using any of the findByXXXAndYYY and related magic methods, I receive an error when specifying a related object as one of the arguments:

``` php
BookQuery::create()->findOneByAuthorAndISBN($author, 1234);
```

This causes the following exception:

```
PropelException: filterByAuthor() only accepts arguments of type Author or PropelCollection
```

This PR should fix that.
