### PR TITLE
Allow underscores in the sqlType xsd regex.

### DIFF
--- a/generator/resources/xsd/database.xsd
+++ b/generator/resources/xsd/database.xsd
@@ -144,7 +144,7 @@
 
 	<xs:simpleType name="sql_type">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="[\w\s\[\]\(\),\.'\-]+"/>
+			<xs:pattern value="[\w\s\[\]\(\),\.'\-_]+"/>
 		</xs:restriction>
 	</xs:simpleType>
 


### PR DESCRIPTION
This is only a fix for the case that I found, but other things such as `enum('~!@#$%^*()','\\')` will probably still fail. The regex should probably be opened up a bit more.
