### PR TITLE
fix findByXXXAndYYY() when one of the parameters is a relation.

### DIFF
--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -242,7 +242,7 @@ class ModelCriteria extends Criteria
 	public function filterByArray($conditions)
 	{
 		foreach ($conditions as $column => $args) {
-			call_user_func_array(array($this, 'filterBy' . $column), (array) $args);
+			call_user_func_array(array($this, 'filterBy' . $column), is_array($args) ? $args : array($args));
 		}
 
 		return $this;

--- a/test/testsuite/runtime/query/ModelCriteriaTest.php
+++ b/test/testsuite/runtime/query/ModelCriteriaTest.php
@@ -2034,6 +2034,24 @@ class ModelCriteriaTest extends BookstoreTestBase
 		$this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'findOneByXXX($value) is turned into findOneBy(XXX, $value)');
 	}
 
+	public function testMagicFindByObject()
+	{
+		$con = Propel::getConnection(BookPeer::DATABASE_NAME);
+		$c = new ModelCriteria('bookstore', 'Author');
+		$testAuthor = $c->findOne();
+		$q = BookQuery::create()
+		  ->findByAuthor($testAuthor);
+		$expectedSQL = "SELECT book.ID, book.TITLE, book.ISBN, book.PRICE, book.PUBLISHER_ID, book.AUTHOR_ID FROM `book` WHERE book.AUTHOR_ID=" . $testAuthor->getId();
+		$this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'findByXXX($value) is turned into findBy(XXX, $value)');
+
+		$c = new ModelCriteria('bookstore', 'Author');
+		$testAuthor = $c->findOne();
+		$q = BookQuery::create()
+		  ->findByAuthorAndISBN($testAuthor, 1234);
+		$expectedSQL = "SELECT book.ID, book.TITLE, book.ISBN, book.PRICE, book.PUBLISHER_ID, book.AUTHOR_ID FROM `book` WHERE book.AUTHOR_ID=" . $testAuthor->getId() . " AND book.ISBN=1234";
+		$this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'findByXXXAndYYY($value) is turned into findBy(array(XXX, YYY), $value)');
+	}
+
 	public function testMagicFilterBy()
 	{
 		$con = Propel::getConnection(BookPeer::DATABASE_NAME);


### PR DESCRIPTION
Refs #158.
Based on a patch by @maikg
