### PR TITLE
Do not specify -dev in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Propel is an open-source Object-Relational Mapping (ORM) for PHP5.",
   "keywords": ["ORM"],
   "homepage": "http://www.propelorm.org/",
-  "version": "1.6.4-dev",
+  "version": "1.6.4",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
The 1.6.2 and 1.6.3 tags have the -dev still in the file, which is a bit fail. Packagist will add the -dev automatically for branches, so this is better.
