### PR TITLE
Fix regression in 1.6.3, where exception is not caught on namespaced obje

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -220,7 +220,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 	{
 		$this->declareClassFromBuilder($this->getStubPeerBuilder());
 		$this->declareClassFromBuilder($this->getStubQueryBuilder());
-		$this->declareClasses('Propel', 'PropelException', 'PDO', 'PropelPDO', 'Criteria', 'BaseObject', 'Persistent', 'BasePeer', 'PropelCollection', 'PropelObjectCollection');
+		$this->declareClasses('Propel', 'PropelException', 'PDO', 'PropelPDO', 'Criteria', 'BaseObject', 'Persistent', 'BasePeer', 'PropelCollection', 'PropelObjectCollection', 'Exception');
 
 		$table = $this->getTable();
 		if (!$table->isAlias()) {


### PR DESCRIPTION
Fix regression in 1.6.3, where exception is not caught on namespaced objects.
Closes #165.
