### PR TITLE
Fix archivable behavior when archive table is in another database.

### DIFF
--- a/generator/lib/behavior/archivable/ArchivableBehavior.php
+++ b/generator/lib/behavior/archivable/ArchivableBehavior.php
@@ -126,20 +126,23 @@ class ArchivableBehavior extends Behavior
 
 	public function getArchiveTablePhpName($builder)
 	{
-		if ($this->getParameter('archive_class') == '') {
-			return $builder->getNewStubObjectBuilder($this->getArchiveTable())->getClassname();
-		} else {
+		if ($this->hasArchiveClass()) {
 			return $this->getParameter('archive_class');
 		}
+		return $builder->getNewStubObjectBuilder($this->getArchiveTable())->getClassname();
 	}
 
 	public function getArchiveTableQueryName($builder)
 	{
-		if ($this->getParameter('archive_class') == '') {
-			return $builder->getNewStubQueryBuilder($this->getArchiveTable())->getClassname();
-		} else {
+		if ($this->hasArchiveClass()) {
 			return $this->getParameter('archive_class') . 'Query';
 		}
+		return $builder->getNewStubQueryBuilder($this->getArchiveTable())->getClassname();
+	}
+	
+	public function hasArchiveClass()
+	{
+		return $this->getParameter('archive_class') != '';
 	}
 
 	/**

--- a/generator/lib/behavior/archivable/ArchivableBehaviorObjectBuilderModifier.php
+++ b/generator/lib/behavior/archivable/ArchivableBehaviorObjectBuilderModifier.php
@@ -137,6 +137,7 @@ class ArchivableBehaviorObjectBuilderModifier
 			'archiveTablePhpName'   => $this->behavior->getArchiveTablePhpName($builder),
 			'archiveTableQueryName' => $this->behavior->getArchiveTableQueryName($builder),
 			'archivedAtColumn'      => $this->behavior->getArchivedAtColumn(),
+			'hasArchiveClass'       => $this->behavior->hasArchiveClass()
 		));
 	}
 

--- a/generator/lib/behavior/archivable/templates/objectArchive.php
+++ b/generator/lib/behavior/archivable/templates/objectArchive.php
@@ -15,7 +15,7 @@ public function archive(PropelPDO $con = null)
 	if ($this->isNew()) {
 		throw new PropelException('New objects cannot be archived. You must save the current object before calling archive().');
 	}
-	if (!$archive = $this->getArchive($con)) {
+	if (!$archive = $this->getArchive(<?php if(!$hasArchiveClass): ?>$con<?php endif; ?>)) {
 		$archive = new <?php echo $archiveTablePhpName ?>();
 		$archive->setPrimaryKey($this->getPrimaryKey());
 	}
@@ -23,7 +23,7 @@ public function archive(PropelPDO $con = null)
 <?php if ($archivedAtColumn): ?>
 	$archive->set<?php echo $archivedAtColumn->getPhpName() ?>(time());
 <?php endif; ?>
-	$archive->save($con);
+	$archive->save(<?php if(!$hasArchiveClass): ?>$con<?php endif; ?>);
 
 	return $archive;
 }


### PR DESCRIPTION
There is a nasty bug causing the `archive()` method to use the wrong connection when called after `delete()`
(this is because we want to enclose the two operations in a transaction when they operate on the same database)
so we need to remove the connection parameter in case the user uses cross-databases archives.
A unit test for this case is quite heavy to set up (two more DBs to create), but I have tested it locally and it is OK.

More details in https://groups.google.com/d/msg/propel-users/c_3xYvxGpKw/grwMXrpjIlYJ
