### PR TITLE
Fix #159 Abstract single table inheritance

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -3428,6 +3428,10 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 		$joinedTableObjectBuilder = $this->getNewObjectBuilder($refFK->getTable());
 		$className = $joinedTableObjectBuilder->getObjectClassname();
 
+		if ($tblFK->getChildrenColumn()) {
+			$className = 'Base' . $className;
+		}
+
 		$collName = $this->getRefFKCollVarName($refFK);
 
 		$script .= "

--- a/generator/lib/builder/om/PHP5PeerBuilder.php
+++ b/generator/lib/builder/om/PHP5PeerBuilder.php
@@ -172,7 +172,7 @@ abstract class ".$this->getClassname(). $extendingPeerClass . " {
 
 	public function getTableMapClass()
 	{
-		return $this->getTablePhpName() . 'TableMap';
+		return $this->getStubObjectBuilder()->getClassname() . 'TableMap';
 	}
 
 	public function getTablePhpName()

--- a/test/fixtures/bookstore/schema.xml
+++ b/test/fixtures/bookstore/schema.xml
@@ -338,11 +338,31 @@
 		</foreign-key>
 	</table>
 
-    <table name="book2">
-        <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" />
-        <column name="title" type="VARCHAR" />
-        <column name="style" type="ENUM" valueSet="novel, essay, poetry" />
-        <column name="tags" type="ARRAY" />
-    </table>
+	<table name="book2">
+		<column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" />
+		<column name="title" type="VARCHAR" />
+		<column name="style" type="ENUM" valueSet="novel, essay, poetry" />
+		<column name="tags" type="ARRAY" />
+	</table>
+
+	<!-- Test single table inheritance with Abstract true -->
+	<table name="distribution" abstract="true">
+		<column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" />
+		<column name="name" type="VARCHAR" />
+		<column name="type" type="INTEGER" required="true" default="0" inheritance="single">
+			<inheritance key="44" class="DistributionStore" />
+			<inheritance key="23" class="DistributionOnline" extends="DistributionStore" />
+			<inheritance key="3838" class="DistributionVirtualStore" extends="DistributionStore" />
+		</column>
+		<column name="distribution_manager_id" type="INTEGER" required="true"/>
+		<foreign-key foreignTable="distribution_manager" onDelete="cascade">
+			<reference local="distribution_manager_id" foreign="id" />
+		</foreign-key>
+	</table>
+
+	<table name="distribution_manager">
+		<column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" />
+		<column name="name" type="VARCHAR" />
+	</table>
 
 </database>

--- a/test/testsuite/generator/builder/om/QueryBuilderInheritanceTest.php
+++ b/test/testsuite/generator/builder/om/QueryBuilderInheritanceTest.php
@@ -116,5 +116,48 @@ class QueryBuilderInheritanceTest extends BookstoreTestBase
 
 		Propel::enableInstancePooling();
 	}
+
+	public function testGetCorrectTableMapClassWithAbstractSingleTableInheritance()
+	{
+		Propel::initialize();
+		$this->assertInstanceOf('DistributionTableMap', DistributionPeer::getTableMap(), 'getTableMap should return the right table map');
+	}
+
+	/**
+	 * This test prove failure with propel.emulateForeignKeyConstraints = true
+	 */
+	public function testDeleteCascadeWithAbstractSingleTableInheritance()
+	{
+		$manager = new DistributionManager();
+		$manager->setName('test');
+		$manager->save();
+		$manager->delete();
+	}
+
+	public function  testFindPkSimpleWithAbstractSingleTableInheritanceReturnCorrectClass()
+	{
+		Propel::disableInstancePooling();
+
+		$manager = new DistributionManager();
+		$manager->setName('manager1');
+		$manager->save();
+
+		$distributionStore = new DistributionStore();
+		$distributionStore->setName('my store 1');
+		$distributionStore->setDistributionManager($manager);
+		$distributionStore->save();
+
+		$distributionVirtualStore = new DistributionVirtualStore();
+		$distributionVirtualStore->setName('my VirtualStore 1');
+		$distributionVirtualStore->setDistributionManager($manager);
+		$distributionVirtualStore->save();
+
+		$this->assertInstanceOf('DistributionStore', DistributionQuery::create()->findPk($distributionStore->getId()),
+			'findPk() return right object : DistributionStore');
+		$this->assertInstanceOf('DistributionVirtualStore', DistributionQuery::create()->findPk($distributionVirtualStore->getId()),
+			'findPk() return right object : DistributionVirtualStore');
+
+		Propel::enableInstancePooling();
+	}
 }
 


### PR DESCRIPTION
Hi,

This fix #159, where a delete cascade fail on Abstract single table inheritance, with propel parameter emulateForeignConstraints = true.

This fix also another bug with single table inheritance where a addRelatedObject fail if added object is not type of the Abstract class.
