### PR TITLE
Fix bug that caused new I18n rows to not return a valid object causing a fatal error.

### DIFF
--- a/generator/lib/behavior/i18n/I18nBehaviorObjectBuilderModifier.php
+++ b/generator/lib/behavior/i18n/I18nBehaviorObjectBuilderModifier.php
@@ -193,7 +193,7 @@ class I18nBehaviorObjectBuilderModifier
 	public function objectFilter(&$script, $builder)
 	{
 		$i18nTable = $this->behavior->getI18nTable();
-		$i18nTablePhpName = $this->builder->getNewStubObjectBuilder($i18nTable)->getClassname();
+		$i18nTablePhpName = $this->builder->getNewStubObjectBuilder($i18nTable)->getUnprefixedClassname();
 		$localeColumnName = $this->behavior->getLocaleColumn()->getPhpName();
 		$pattern = '/public function add' . $i18nTablePhpName . '.*[\r\n]\s*\{/';
 		$addition = "


### PR DESCRIPTION
In my case this was causing a fatal error due to a call to `getTranslation` returning `NULL`.

```
$issue = new DB_issue();
$issue->getName();
```

Schema:

```
 <database>
    <table name="issue" phpName="issue">
        <vendor type="mysql">
            <parameter name="Charset" value="utf8"/>
        </vendor>
        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true"/>
        <column name="name" type="varchar" size="255" required="true"/>
        <column name="thumbnail_url" type="varchar" required="false"/>
        <column name="pdf_url" type="varchar" required="true"/>
        <column name="activate_at" type="timestamp" required="true"/>
        <behavior name="timestampable"/>
        <behavior name="i18n">
            <parameter name="i18n_columns" value="name, thumbnail_url, pdf_url"/>
            <parameter name="i18n_phpname" value="issue_i18n"/>
            <parameter name="default_locale" value="en_US"/>
        </behavior>
    </table>
</database>
```
