### PR TITLE
Fix archivable behavior when used with unique index.

### DIFF
--- a/generator/lib/behavior/archivable/ArchivableBehavior.php
+++ b/generator/lib/behavior/archivable/ArchivableBehavior.php
@@ -100,11 +100,18 @@ class ArchivableBehavior extends Behavior
 				$copiedIndex->setName('');
 				$archiveTable->addIndex($copiedIndex);
 			}
-			// copy unique indices
+			// copy unique indices to indices
+			// see https://github.com/propelorm/Propel/issues/175 for details
 			foreach ($table->getUnices() as $unique) {
-				$copiedUnique = clone $unique;
-				$copiedUnique->setName('');
-				$archiveTable->addUnique($copiedUnique);
+				$index = new Index();
+				foreach ($unique->getColumns() as $columnName) {
+					if ($size = $unique->getColumnSize($columnName)) {
+						$index->addColumn(array('name' => $columnName, 'size' => $size));
+					} else {
+						$index->addColumn(array('name' => $columnName));
+					}
+				}
+				$archiveTable->addIndex($index);
 			}
 			// every behavior adding a table should re-execute database behaviors
 			foreach ($database->getBehaviors() as $behavior) {

--- a/test/testsuite/generator/behavior/archivable/ArchivableBehaviorTest.php
+++ b/test/testsuite/generator/behavior/archivable/ArchivableBehaviorTest.php
@@ -61,6 +61,9 @@ class ArchivableBehaviorTest extends PHPUnit_Framework_TestCase
 		<column name="title" type="VARCHAR" size="100" primaryString="true" />
 		<column name="age" type="INTEGER" />
 		<column name="foo_id" type="INTEGER" />
+		<unique>
+			<unique-column name="title" />
+		</unique>
 		<behavior name="archivable">
 			<parameter name="log_archived_at" value="false" />
 			<parameter name="archive_table" value="my_old_archivable_test_3" />
@@ -132,6 +135,13 @@ EOF;
 	{
 		$table = ArchivableTest1ArchivePeer::getTableMap();
 		$expected = "CREATE INDEX archivable_test_1_archive_I_1 ON archivable_test_1_archive (title,age);";
+		$this->assertContains($expected, self::$generatedSQL);
+	}
+
+	public function testCopiesUniquesToIndices()
+	{
+		$table = ArchivableTest2ArchivePeer::getTableMap();
+		$expected = "CREATE INDEX my_old_archivable_test_3_I_1 ON my_old_archivable_test_3 (title);";
 		$this->assertContains($expected, self::$generatedSQL);
 	}
 


### PR DESCRIPTION
If a table has unique columns, the resulting archive table has set
UNIQUE indices on these columns.

While this seems like a good idea at the first glance, it's a bug
because you can't delete two records which share the same value in this
colum.

This patch fixes the issue by copying unique indices to indices on the
archive table.

Closes #175.
