### PR TITLE
Bug in query_cache behavior when it use with namespace

### DIFF
--- a/generator/lib/behavior/query_cache/QueryCacheBehavior.php
+++ b/generator/lib/behavior/query_cache/QueryCacheBehavior.php
@@ -46,6 +46,7 @@ class QueryCacheBehavior extends Behavior
 
 	public function queryMethods($builder)
 	{
+		$builder->declareClasses('BasePeer');
 		$this->peerClassname = $builder->getStubPeerBuilder()->getClassname();
 		$script = '';
 		$this->addSetQueryKey($script);


### PR DESCRIPTION
The BasePeer class is use in the method added with this behavior. But BasePeer isn't declared in the Query classes.

When you use query_cache with name space, you got : "Fatal error: Class 'OpenSondage\Database\om\BasePeer' not found" because BasePeer is use without there namespace "BasePeer" and not "\BasePeer"

Only declare BasePeer class in the behavior to solve the problem (for add "use \BasePeer" in the Query classe)

To reproduce the error : https://gist.github.com/1353309
