### PR TITLE
[Generator] remove pk value when copy object with single PK 

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -4952,11 +4952,15 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
 	{";
 
 		$autoIncCols = array();
-		foreach ($table->getColumns() as $col) {
-			/* @var        $col Column */
-			if ($col->isAutoIncrement()) {
-				$autoIncCols[] = $col;
+		if ($table->hasCompositePrimaryKey()) {
+			foreach ($table->getColumns() as $col) {
+				/* @var        $col Column */
+				if ($col->isAutoIncrement()) {
+					$autoIncCols[] = $col;
+				}
 			}
+		} else {
+			$autoIncCols = $table->getPrimaryKey();
 		}
 
 		foreach ($table->getColumns() as $col) {

--- a/test/testsuite/generator/builder/om/GeneratedObjectTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectTest.php
@@ -679,6 +679,20 @@ class GeneratedObjectTest extends BookstoreTestBase
         $this->assertEquals($op->getBookId(), $opinions[0]->getBookId());
     }
 
+    /**
+     *
+     */
+    public function testCopyConcretInheritance()
+    {
+        $concreteArticle = new ConcreteArticle();
+        $concreteArticle->setBody('TestBody');
+        $concreteArticle->save();
+
+        $copy = $concreteArticle->copy();
+
+        $this->assertNull($copy->getId(), "single PK not autoincremented shouldn't be copied");
+    }
+
     public function testToArray()
     {
         $b = new Book();


### PR DESCRIPTION
Hi,

This fix the first part of the issue #192

It prevent copy of pk value not autoincremented when the pk is not composite.

All tests passed.

but maybe we should add extra test
