### PR TITLE
add namespace to check for duplicate table phpName

### DIFF
--- a/generator/lib/util/PropelSchemaValidator.php
+++ b/generator/lib/util/PropelSchemaValidator.php
@@ -47,11 +47,20 @@ class PropelSchemaValidator
 	protected function validateDatabaseTables(Database $database)
 	{
 		$phpNames = array();
+		$namespaces = array();
 		foreach ($database->getTables() as $table) {
-			if (in_array($table->getPhpName(), $phpNames)) {
+			$list = &$phpNames;
+			if ($table->getNamespace()) {
+				if (!isset($namespaces[$table->getNamespace()])) {
+					$namespaces[$table->getNamespace()] = array();
+				}
+
+				$list = &$namespaces[$table->getNamespace()];
+			}
+			if (in_array($table->getPhpName(), $list)) {
 				$this->errors[] = sprintf('Table "%s" declares a phpName already used in another table', $table->getName());
 			}
-			$phpNames[]= $table->getPhpName();
+			$list[]= $table->getPhpName();
 			$this->validateTableAttributes($table);
 			$this->validateTableColumns($table);
 		}

--- a/test/testsuite/generator/util/PropelSchemaValidatorTest.php
+++ b/test/testsuite/generator/util/PropelSchemaValidatorTest.php
@@ -68,6 +68,30 @@ EOF;
 		$this->assertContains('Table "bar" declares a phpName already used in another table', $validator->getErrors());
 	}
 
+	public function testValidateReturnsTrueWhenTwoTablesHaveSamePhpNameInDifferentNamespaces()
+	{
+		$column1 = new Column('id');
+		$column1->setPrimaryKey(true);
+		$table1 = new Table('foo');
+		$table1->addColumn($column1);
+		$table1->setNamespace('Foo');
+
+		$column2 = new Column('id');
+		$column2->setPrimaryKey(true);
+		$table2 = new Table('bar');
+		$table2->addColumn($column2);
+		$table2->setPhpName('Foo');
+		$table2->setNamespace('Bar');
+
+		$database = new Database();
+		$database->addTable($table1);
+		$database->addTable($table2);
+		$appData = new AppData();
+		$appData->addDatabase($database);
+		$validator = new PropelSchemaValidator($appData);
+		$this->assertTrue($validator->validate());
+	}
+
 	public function testValidateReturnsFalseWhenTableHasNoPk()
 	{
 		$appData = $this->getAppDataForTable(new Table('foo'));


### PR DESCRIPTION
The same phpName for a table should be valid if the models are in different namespaces.
