### PR TITLE
Fixing issue #248

### DIFF
--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -535,8 +535,7 @@ class ModelCriteria extends Criteria
 		}
 
 		// select() needs the PropelSimpleArrayFormatter if no formatter given
-		if (is_null($this->getFormatter()))
- 		{
+		if (is_null($this->getFormatter())) {
 				$this->setFormatter('PropelSimpleArrayFormatter');
 		}
 


### PR DESCRIPTION
The formatter is now overriden in configureSelectColumns only if it was not already set, allowing us to use a custom formatter with select.
