### PR TITLE
Fixing issue #248

### DIFF
--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -535,7 +535,7 @@ class ModelCriteria extends Criteria
 		}
 
 		// select() needs the PropelSimpleArrayFormatter if no formatter given
-		if (is_null($this->getFormatter())) {
+		if (is_null($this->formatter)) {
 				$this->setFormatter('PropelSimpleArrayFormatter');
 		}
 


### PR DESCRIPTION
We check if a formatter was already set. Enabling the use of a custom formatter and PropelQuery::select().
