### PR TITLE
Fix issue #227 :  Small change in ModelCriteria, to make it work with peer constants

### DIFF
--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -1918,33 +1918,38 @@ class ModelCriteria extends Criteria
 	protected function getColumnFromName($phpName, $failSilently = true)
 	{
 		if (strpos($phpName, '.') === false) {
-			$class = $this->getModelAliasOrName();
+			$prefix = $this->getModelAliasOrName();
 		} else {
-			list($class, $phpName) = explode('.', $phpName);
+			// $prefix could be either class name or table name
+			list($prefix, $phpName) = explode('.', $phpName);
 		}
 
-		if ($class == $this->getModelAliasOrName()) {
-			// column of the Criteria's model
+		if ($prefix == $this->getModelAliasOrName() || $prefix == $this->getTableMap()->getName()) {
+			// column of the Criteria's model, or column name from Criteria's peer
 			$tableMap = $this->getTableMap();
-		} elseif (isset($this->joins[$class])) {
+		} elseif (isset($this->joins[$prefix])) {
 			// column of a relations's model
-			$tableMap = $this->joins[$class]->getTableMap();
-		} elseif ($this->hasSelectQuery($class)) {
-			return $this->getColumnFromSubQuery($class, $phpName, $failSilently);
+			$tableMap = $this->joins[$prefix]->getTableMap();
+		} elseif ($this->hasSelectQuery($prefix)) {
+			return $this->getColumnFromSubQuery($prefix, $phpName, $failSilently);
 		} elseif ($failSilently) {
 			return array(null, null);
 		} else {
-			throw new PropelException(sprintf('Unknown model or alias "%s"', $class));
+			throw new PropelException(sprintf('Unknown model, alias or table "%s"', $prefix));
 		}
 
 		if ($tableMap->hasColumnByPhpName($phpName)) {
 			$column = $tableMap->getColumnByPhpName($phpName);
-			if (isset($this->aliases[$class])) {
-				$this->currentAlias = $class;
-				$realColumnName = $class . '.' . $column->getName();
+			if (isset($this->aliases[$prefix])) {
+				$this->currentAlias = $prefix;
+				$realColumnName = $prefix . '.' . $column->getName();
 			} else {
 				$realColumnName = $column->getFullyQualifiedName();
 			}
+			return array($column, $realColumnName);
+		} elseif ($tableMap->hasColumn($phpName,false)) {
+			$column = $tableMap->getColumn($phpName,false);
+			$realColumnName = $column->getFullyQualifiedName();
 			return array($column, $realColumnName);
 		} elseif (isset($this->asColumns[$phpName])) {
 			// aliased column
@@ -1952,7 +1957,7 @@ class ModelCriteria extends Criteria
 		} elseif ($failSilently) {
 			return array(null, null);
 		} else {
-			throw new PropelException(sprintf('Unknown column "%s" on model or alias "%s"', $phpName, $class));
+			throw new PropelException(sprintf('Unknown column "%s" on model, alias or table "%s"', $phpName, $prefix));
 		}
 	}
 

--- a/test/testsuite/runtime/query/ModelCriteriaSelectTest.php
+++ b/test/testsuite/runtime/query/ModelCriteriaSelectTest.php
@@ -98,6 +98,25 @@ class ModelCriteriaSelectTest extends BookstoreTestBase
 		$this->assertEquals($authors->count(), 1, 'find() called after select(string) allows for where() statements');
 		$expectedSQL = "SELECT author.FIRST_NAME AS \"FirstName\" FROM `author` WHERE author.FIRST_NAME = 'Neal'";
 		$this->assertEquals($expectedSQL, $this->con->getLastExecutedQuery(), 'find() called after select(string) allows for where() statements');
+		
+		$c = new ModelCriteria('bookstore', 'Author');
+		$c->select(AuthorPeer::FIRST_NAME);
+		$author = $c->find($this->con);
+		$expectedSQL = "SELECT author.FIRST_NAME AS \"author.FIRST_NAME\" FROM `author`";
+		$this->assertEquals($expectedSQL, $this->con->getLastExecutedQuery(), 'select(string) accepts model Peer Constants');
+	}
+	
+	/**
+	* @expectedException PropelException
+	*/
+	public function testSelectStringFindCalledWithNonExistingColumn()
+	{
+		BookstoreDataPopulator::depopulate($this->con);
+		BookstoreDataPopulator::populate($this->con);
+	
+		$c = new ModelCriteria('bookstore', 'Author');
+		$c->select('author.NOT_EXISTING_COLUMN');
+		$author = $c->find($this->con);
 	}
 
 	public function testSelectStringFindOne()
@@ -121,7 +140,7 @@ class ModelCriteriaSelectTest extends BookstoreTestBase
 		$expectedSQL = "SELECT author.FIRST_NAME AS \"FirstName\" FROM `author` WHERE author.FIRST_NAME = 'Neal' LIMIT 1";
 		$this->assertEquals($expectedSQL, $this->con->getLastExecutedQuery(), 'findOne() called after select(string) allows for where() statements');
 	}
-
+	
 	public function testSelectStringJoin()
 	{
 		BookstoreDataPopulator::depopulate($this->con);


### PR DESCRIPTION
This patch fixes the [issue#227](https://github.com/propelorm/Propel/issues/227), which is opened by @hades200082.
AFAIU, ModelCriteria->select() method doesn't work with column name constants  of model's Peer Class. 

``` php
        // this works
    $c = new \Criteria();
    $c->clearSelectColumns();
    $c->addSelectColumn(AuthorPeer::FIRST_NAME); 

        // this doesn't work
    $authors = AuthorQuery::create()
    ->select(AuthorPeer::FIRST_NAME)
```

I made a small change in ModelCriteria->getColumnFromName() method to overcome this problem.
Another point is, the [issue#227](https://github.com/propelorm/Propel/issues/227) complains about "setDistinct()" method but the actual problem (if I am not mistaken) is in "getColumnFromName()" method. It just doesnt support column names in "tableName.ColumnName" format and this is what I added. Lastly this format may be unsupported by design, you can ignore the changes if this is the case :)
