### PR TITLE
Update the exception thrown by findOneOrCreate() when used with a join.

### DIFF
--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -1174,6 +1174,9 @@ class ModelCriteria extends Criteria
 	 */
 	public function findOneOrCreate($con = null)
 	{
+		if ($this->joins) {
+			throw new PropelException('findOneOrCreate() cannot be used on a query with a join, because Propel cannot transform a SQL JOIN into a subquery. You should split the query in two queries to avoid joins.');
+		}
 		if (!$ret = $this->findOne($con)) {
 			$class = $this->getModelName();
 			$obj = new $class();

--- a/test/testsuite/runtime/query/ModelCriteriaTest.php
+++ b/test/testsuite/runtime/query/ModelCriteriaTest.php
@@ -1505,6 +1505,19 @@ class ModelCriteriaTest extends BookstoreTestBase
 		$this->assertEquals(125, $book->getPrice(), 'findOneOrCreate() returns a populated objects based on the conditions');
 	}
 
+	/**
+	 * @expectedException PropelException
+	 */
+	public function testFindOneOrCreateThrowsExceptionWhenQueryContainsJoin()
+	{
+		$book = BookQuery::create('b')
+			->filterByPrice(125)
+			->useAuthorQuery()
+				->filterByFirstName('Leo')
+			->endUse()
+			->findOneOrCreate();
+	}
+
 	public function testFindOneOrCreateMakesOneQueryWhenRecordNotExists()
 	{
 		$con = Propel::getConnection(BookPeer::DATABASE_NAME);


### PR DESCRIPTION
When using a join() (or a useXXXQuery()) on a query, and then terminating with
findOneOrCreate(), Propel used to throw a non-explicit exception only in the case
where there was no result found:

```
PropelException: 'author.FIRST_NAME' could not be found in the field names
    of type 'colName'. These are: Array
...
```

The problem is that Propel cannot set the foreign key value, as the main
query uses a join and not a subquery. So Propel _should_ indeed throw an
exception, but it should explain what to do more clearly:

```
PropelException: findOneOrCreate() cannot be used on a query with a join,
    because Propel cannot transform a SQL JOIN into a subquery.
    You should split the query in two queries to avoid joins.
```

This exception is now also thrown when the query has a result, to help spot
the problem during development (and not in production).

Fixes #261.
