### PR TITLE
Fix DTD for behaviors without parameters

### DIFF
--- a/generator/resources/dtd/database.dtd
+++ b/generator/resources/dtd/database.dtd
@@ -140,7 +140,7 @@ PHP class or method name.
   name CDATA #IMPLIED
 >
 
-<!ELEMENT behavior (parameter+)>
+<!ELEMENT behavior (parameter*)>
 <!ATTLIST behavior
   name CDATA #IMPLIED
 >


### PR DESCRIPTION
`<parameter />` tags inside behaviors are optional. The current DTD schema fails when including a behavior like `<behavior name="auto_add_pk" />`.
