### PR TITLE
Fix: some isVersionningNecessary() calls can cause fatal errors

### DIFF
--- a/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -184,7 +184,7 @@ public function isVersioningNecessary(\$con = null)
 		foreach ($this->behavior->getVersionableFks() as $fk) {
 			$fkGetter = $this->builder->getFKPhpNameAffix($fk, $plural = false);
 			$script .= "
-	if (\$this->get{$fkGetter}(\$con)->isVersioningNecessary(\$con)) {
+	if (null !== (\$object = \$this->get{$fkGetter}(\$con)) && \$object->isVersioningNecessary(\$con)) {
 		return true;
 	}
 ";

--- a/test/testsuite/generator/behavior/versionable/VersionableBehaviorObjectBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/versionable/VersionableBehaviorObjectBuilderModifierTest.php
@@ -505,6 +505,19 @@ EOF;
 		$this->assertFalse($a->isVersioningNecessary());
 	}
 
+	public function testIsVersioningNecessaryWithNullFk()
+	{
+		// the purpose of this tests is to highlight a bug with FK and isVersioningNecessary()
+		$b1 = new VersionableBehaviorTest5();
+		$b1->setNew(false);
+
+		// this time, the object isn't modified, so the isVersioningNecessary()
+		// method is called on FK objects... which can be null.
+		$b1->isVersioningNecessary();
+
+		$this->assertTrue(true, 'getting here means that nothing went wrong');
+	}
+
 	public function testAddVersionNewObject()
 	{
 		VersionableBehaviorTest1Peer::disableVersioning();


### PR DESCRIPTION
Given the following model, some isVersionningNecessary() calls would cause
fatal errors.

```
User                              Group
----                              -----
name                              name
group_id [FK, not required]
```

When saving an user with no group but a name, the isVersioningNecessary()
method returns true because the object is modified. But if we save again the
same user - as there are no modifications on the user - the foreign keys
are checked and isVersioningNecessary() is called on them, which causes
a fatal error when one of them is not set.

In fact, calling isVersioningNecessary() on any not-new, not modifiable object, with null foreign keys will cause a fatal error.
