### PR TITLE
Fix PropelModelPager::getLastPage() return type.

### DIFF
--- a/runtime/lib/util/PropelModelPager.php
+++ b/runtime/lib/util/PropelModelPager.php
@@ -71,7 +71,7 @@ class PropelModelPager implements IteratorAggregate, Countable
 		if (($this->getPage() == 0 || $this->getMaxPerPage() == 0)) {
 			$this->setLastPage(0);
 		} else {
-			$this->setLastPage(ceil($this->getNbResults() / $this->getMaxPerPage()));
+			$this->setLastPage((int)ceil($this->getNbResults() / $this->getMaxPerPage()));
 
 			$offset = ($this->getPage() - 1) * $this->getMaxPerPage();
 			$q->offset($offset);

--- a/test/testsuite/runtime/util/PropelModelPagerTest.php
+++ b/test/testsuite/runtime/util/PropelModelPagerTest.php
@@ -158,6 +158,14 @@ class PropelModelPagerTest extends BookstoreEmptyTestBase
 		$this->assertTrue($pager->isLastPage(), 'isLastPage() returns true on the last page');
 	}
 
+	public function testGetLastPage()
+	{
+		$this->createBooks(5);
+		$pager = $this->getPager(4, 1);
+		$this->assertEquals(2, $pager->getLastPage(), 'getLastPage() returns the last page number');
+		$this->assertInternalType('integer', $pager->getLastPage(), 'getLastPage() returns an integer');
+	}
+
 	public function testIsFirstOnFirstPage()
 	{
 		$this->createBooks(5);


### PR DESCRIPTION
Turns out that PHP's `ceil()` converts a float to an integer but still returns... a float.
The patch forces the return type of `getLastPage()` by casting to integer after calling `ceil()`.

Closes #316.
