### PR TITLE
Add: some usefull methods to Versionable objects

### DIFF
--- a/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -129,7 +129,10 @@ class VersionableBehaviorObjectBuilderModifier
 		$this->addIsLastVersion($script);
 		$this->addGetOneVersion($script);
 		$this->addGetAllVersions($script);
+		$this->addCompareVersion($script);
 		$this->addCompareVersions($script);
+		$this->addComputeDiff($script);
+		$this->addGetLastVersions($script);
 		return $script;
 	}
 
@@ -472,7 +475,7 @@ public function getAllVersions(\$con = null)
 ";
 	}
 
-	protected function addCompareVersions(&$script)
+	protected function addComputeDiff(&$script)
 	{
 		$versionTable = $this->behavior->getVersionTable();
 		$versionARClassname = $this->builder->getNewStubObjectBuilder($versionTable)->getClassname();
@@ -481,27 +484,27 @@ public function getAllVersions(\$con = null)
 		$relCol = $this->builder->getRefFKPhpNameAffix($fks[0], $plural = true);
 		$script .= "
 /**
- * Gets all the versions of this object, in incremental order.
+ * Computes the diff between two versions.
  * <code>
- * print_r(\$book->compare(1, 2));
+ * print_r(\$this->computeDiff(1, 2));
  * => array(
  *   '1' => array('Title' => 'Book title at version 1'),
  *   '2' => array('Title' => 'Book title at version 2')
  * );
  * </code>
  *
- * @param   integer   \$fromVersionNumber
- * @param   integer   \$toVersionNumber
- * @param   string    \$keys Main key used for the result diff (versions|columns)
- * @param   PropelPDO \$con the connection to use
+ * @param   array     \$fromVersion     An array representing the original version.
+ * @param   array     \$toVersion       An array representing the destination version.
+ * @param   string    \$keys            Main key used for the result diff (versions|columns).
+ * @param   array     \$ignoredColumns  The columns to exclude from the diff.
  *
  * @return  array A list of differences
  */
-public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys = 'columns', \$con = null)
+protected function computeDiff(\$fromVersion, \$toVersion, \$keys = 'columns', \$ignoredColumns = array())
 {
-	\$fromVersion = \$this->getOneVersion(\$fromVersionNumber, \$con)->toArray();
-	\$toVersion = \$this->getOneVersion(\$toVersionNumber, \$con)->toArray();
-	\$ignoredColumns = array(
+	\$fromVersionNumber = \$fromVersion['{$this->getColumnPhpName()}'];
+	\$toVersionNumber = \$toVersion['{$this->getColumnPhpName()}'];
+	\$ignoredColumns = array_merge(array(
 		'{$this->getColumnPhpName()}',";
 		if ($this->behavior->getParameter('log_created_at') == 'true') {
 			$script .= "
@@ -516,7 +519,7 @@ public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys =
 		'VersionComment',";
 		}
 		$script .= "
-	);
+	), \$ignoredColumns);
 	\$diff = array();
 	foreach (\$fromVersion as \$key => \$value) {
 		if (in_array(\$key, \$ignoredColumns)) {
@@ -540,5 +543,93 @@ public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys =
 	return \$diff;
 }
 ";
+  }
+
+	protected function addCompareVersion(&$script)
+	{
+		$script .= "
+/**
+ * Compares the current object with another of its version.
+ * <code>
+ * print_r(\$book->compareVersion(1));
+ * => array(
+ *   '1' => array('Title' => 'Book title at version 1'),
+ *   '2' => array('Title' => 'Book title at version 2')
+ * );
+ * </code>
+ *
+ * @param   integer   \$versionNumber
+ * @param   string    \$keys Main key used for the result diff (versions|columns)
+ * @param   PropelPDO \$con the connection to use
+ * @param   array     \$ignoredColumns  The columns to exclude from the diff.
+ *
+ * @return  array A list of differences
+ */
+public function compareVersion(\$versionNumber, \$keys = 'columns', \$con = null, \$ignoredColumns = array())
+{
+	\$fromVersion = \$this->toArray();
+	\$toVersion = \$this->getOneVersion(\$versionNumber, \$con)->toArray();
+
+	return \$this->computeDiff(\$fromVersion, \$toVersion, \$keys, \$ignoredColumns);
+}
+";
+  }
+
+	protected function addCompareVersions(&$script)
+	{
+		$script .= "
+/**
+ * Compares two versions of the current object.
+ * <code>
+ * print_r(\$book->compareVersions(1, 2));
+ * => array(
+ *   '1' => array('Title' => 'Book title at version 1'),
+ *   '2' => array('Title' => 'Book title at version 2')
+ * );
+ * </code>
+ *
+ * @param   integer   \$fromVersionNumber
+ * @param   integer   \$toVersionNumber
+ * @param   string    \$keys Main key used for the result diff (versions|columns)
+ * @param   PropelPDO \$con the connection to use
+ * @param   array     \$ignoredColumns  The columns to exclude from the diff.
+ *
+ * @return  array A list of differences
+ */
+public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys = 'columns', \$con = null, \$ignoredColumns = array())
+{
+	\$fromVersion = \$this->getOneVersion(\$fromVersionNumber, \$con)->toArray();
+	\$toVersion = \$this->getOneVersion(\$toVersionNumber, \$con)->toArray();
+
+	return \$this->computeDiff(\$fromVersion, \$toVersion, \$keys, \$ignoredColumns);
+}
+";
 	}
+
+	protected function addGetLastVersions(&$script)
+	{
+		$versionTable = $this->behavior->getVersionTable();
+		$versionARClassname = $this->builder->getNewStubObjectBuilder($versionTable)->getClassname();
+		$versionForeignColumn = $versionTable->getColumn($this->behavior->getParameter('version_column'));
+		$fks = $versionTable->getForeignKeysReferencingTable($this->table->getName());
+		$relCol = $this->builder->getRefFKPhpNameAffix($fks[0], $plural = true);
+		$versionGetter = 'get'.$relCol;
+		$versionPeer = $this->builder->getNewStubPeerBuilder($versionTable)->getClassname();
+
+		$script .= <<<EOF
+/**
+ * retrieve the last \$number versions.
+ *
+ * @param Integer \$number the number of record to return.
+ * @return PropelCollection|array {$versionARClassname}[] List of {$versionARClassname} objects
+ */
+public function getLastVersions(\$number = 10, \$criteria = null, \$con = null)
+{
+	\$criteria = {$this->getVersionQueryClassName()}::create(null, \$criteria);
+	\$criteria->addDescendingOrderByColumn({$versionPeer}::VERSION);
+	\$criteria->limit(\$number);
+	return \$this->{$versionGetter}(\$criteria, \$con);
+}
+EOF;
+  }
 }

--- a/test/testsuite/generator/behavior/versionable/VersionableBehaviorObjectBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/versionable/VersionableBehaviorObjectBuilderModifierTest.php
@@ -643,6 +643,69 @@ EOF;
 		$this->assertEquals(456, $versions[1]->getBar());
 	}
 
+	public function testGetLastVersions()
+	{
+		$o = new VersionableBehaviorTest1();
+		$versions = $o->getAllVersions();
+		$this->assertTrue($versions->isEmpty());
+		$o->setBar(123); // version 1
+		$o->save();
+		$o->setBar(456); // version 2
+		$o->save();
+		$o->setBar(789); // version 3
+		$o->save();
+		$o->setBar(101112); // version 4
+		$o->save();
+
+		$versions = $o->getLastVersions();
+		$this->assertTrue($versions instanceof PropelObjectCollection);
+		$this->assertEquals(4, $versions->count());
+		$this->assertEquals(4, $versions[0]->getVersion());
+		$this->assertEquals(101112, $versions[0]->getBar());
+		$this->assertEquals(3, $versions[1]->getVersion());
+		$this->assertEquals(789, $versions[1]->getBar());
+		$this->assertEquals(2, $versions[2]->getVersion());
+		$this->assertEquals(456, $versions[2]->getBar());
+		$this->assertEquals(1, $versions[3]->getVersion());
+		$this->assertEquals(123, $versions[3]->getBar());
+
+		$versions = $o->getLastVersions(2);
+		$this->assertTrue($versions instanceof PropelObjectCollection);
+		$this->assertEquals(2, $versions->count());
+		$this->assertEquals(4, $versions[0]->getVersion());
+		$this->assertEquals(101112, $versions[0]->getBar());
+		$this->assertEquals(3, $versions[1]->getVersion());
+		$this->assertEquals(789, $versions[1]->getBar());
+	}
+
+	public function testCompareVersion()
+	{
+		$o = new VersionableBehaviorTest4();
+		$versions = $o->getAllVersions();
+		$this->assertTrue($versions->isEmpty());
+		$o->setBar(123); // version 1
+		$o->save();
+		$o->setBar(456); // version 2
+		$o->save();
+		$o->setBar(789); // version 3
+		$o->setVersionComment('Foo');
+		$o->save();
+		$diff = $o->compareVersion(3); // $o is in version 3
+		$expected = array();
+		$this->assertEquals($expected, $diff);
+		$diff = $o->compareVersion(2);
+		$expected = array(
+			'Bar' => array(2 => 456, 3 => 789),
+		);
+		$this->assertEquals($expected, $diff);
+
+		$diff = $o->compareVersion(1);
+		$expected = array(
+			'Bar' => array(1 => 123, 3 => 789),
+		);
+		$this->assertEquals($expected, $diff);
+	}
+
 	public function testCompareVersions()
 	{
 		$o = new VersionableBehaviorTest4();


### PR DESCRIPTION
This PR adds two methods to versionable objects:
- `getLastVersions($max, $criteria, $con)`: retrieves the $max last
  versions
- `compareVersion($number)`: compares the current object to a given
  version.

I also added the `$ignoredColumns` parameter to the compareVersion(s)
methods.
