### PR TITLE
Have class autoloader work for Propel runtime classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,8 @@
   ],
   "require": {
     "php": ">=5.2.4"
+  },
+  "autoload": {
+    "psr-0": { "Propel": "vendor/propel/propel1/runtime/lib/" }
   }
 }


### PR DESCRIPTION
Make Propel work with auto-load in composer context
