### PR TITLE
Fix: versioning tables with inheritance

### DIFF
--- a/generator/lib/behavior/versionable/VersionableBehavior.php
+++ b/generator/lib/behavior/versionable/VersionableBehavior.php
@@ -126,6 +126,7 @@ class VersionableBehavior extends Behavior
 			// copy all the columns
 			foreach ($table->getColumns() as $column) {
 				$columnInVersionTable = clone $column;
+				$columnInVersionTable->clearInheritanceList();
 				if ($columnInVersionTable->hasReferrers()) {
 					$columnInVersionTable->clearReferrers();
 				}

--- a/generator/lib/model/Column.php
+++ b/generator/lib/model/Column.php
@@ -800,6 +800,11 @@ class Column extends XMLElement
 		$this->referrers = null;
 	}
 
+	public function clearInheritanceList()
+	{
+		$this->inheritanceList = array();
+	}
+
 	/**
 	 * Sets the domain up for specified Propel type.
 	 *

--- a/generator/lib/util/PropelQuickBuilder.php
+++ b/generator/lib/util/PropelQuickBuilder.php
@@ -169,14 +169,15 @@ class PropelQuickBuilder
 			if ($col->isEnumeratedClasses()) {
 				foreach ($col->getChildren() as $child) {
 					if ($child->getAncestor()) {
-						$builder = $this->getConfig()->getConfiguredBuilder('queryinheritance', $target);
+						$builder = $this->getConfig()->getConfiguredBuilder($table, 'queryinheritance');
 						$builder->setChild($child);
 						$script .= $builder->build();
-					}
-					foreach (array('objectmultiextend', 'queryinheritancestub') as $target) {
-						$builder = $this->getConfig()->getConfiguredBuilder($table, $target);
-						$builder->setChild($child);
-						$script .= $builder->build();
+
+						foreach (array('objectmultiextend', 'queryinheritancestub') as $target) {
+							$builder = $this->getConfig()->getConfiguredBuilder($table, $target);
+							$builder->setChild($child);
+							$script .= $builder->build();
+						}
 					}
 				}
 			}

--- a/test/testsuite/generator/behavior/versionable/VersionableBehaviorObjectBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/versionable/VersionableBehaviorObjectBuilderModifierTest.php
@@ -110,6 +110,11 @@ EOF;
 			<table name="VersionableBehaviorTest8">
 				<column name="alter_id" primaryKey="true" type="INTEGER" autoIncrement="true" />
 				<column name="FooBar" type="VARCHAR" size="100" />
+				<column name="class_key" type="INTEGER" required="true" default="1" inheritance="single">
+					<inheritance key="1" class="VersionableBehaviorTest8" />
+					<inheritance key="2" class="VersionableBehaviorTest8Foo" extends="VersionableBehaviorTest8" />
+					<inheritance key="3" class="VersionableBehaviorTest8Bar" extends="VersionableBehaviorTest8Foo" />
+				</column>
 				<behavior name="versionable" />
 			</table>
 
@@ -747,4 +752,15 @@ EOF;
 		$b1->save();
 	}
 
+  public function testWithInheritance()
+  {
+		$b1 = new VersionableBehaviorTest8Foo();
+		$b1->save();
+
+		$b1->setFoobar('name');
+		$b1->save();
+
+		$object = $b1->getOneVersion($b1->getVersion());
+		$this->assertTrue($object instanceof Versionablebehaviortest8Version);
+  }
 }


### PR DESCRIPTION
When wersioning a table with inheritance, the `getOneVersion` method
did not return a "Version" object.

Calling `getOneVersion` on a versioned Novel (instance of Book) would
have returned a Book object, instead of a BookVersion object.

Furthermore, the QuickBuilder was broken for this kind of schema and
needed to be fixed.
