### PR TITLE
fix #320 reverse engineering : select tablename can returns quoted name ...

### DIFF
--- a/generator/lib/reverse/mssql/MssqlSchemaParser.php
+++ b/generator/lib/reverse/mssql/MssqlSchemaParser.php
@@ -236,14 +236,16 @@ class MssqlSchemaParser extends BaseSchemaParser
 	}
 
   /**
-   * according to the identifier definition, we have to clean simple quote ('), double quotes (") or brackets ([])
-   * around the identifier name returns by mssql
+   * according to the identifier definition, we have to clean simple quote (') around the identifier name
+   * returns by mssql
    * @see http://msdn.microsoft.com/library/ms175874.aspx
-   * @param $str string
+   *
+   * @param string $identifier
    * @return string
    */
-  public function cleanDelimitedIdentifiers( $str ) {
-    return preg_replace( '/^\'(.*)\'$/U', '$1', $str );
+  protected function cleanDelimitedIdentifiers($identifier)
+  {
+    return preg_replace('/^\'(.*)\'$/U', '$1', $identifier);
   }
 
 }

--- a/test/testsuite/generator/reverse/mssql/MssqlSchemaParserTest.php
+++ b/test/testsuite/generator/reverse/mssql/MssqlSchemaParserTest.php
@@ -22,40 +22,48 @@ class MssqlSchemaParserTest extends PHPUnit_Framework_TestCase
 {
   public function testCleanDelimitedIdentifiers()
   {
-    $parser = new MssqlSchemaParser(null);
+    $parser = new TestableMssqlSchemaParser(null);
 
     $expected = 'this is a tablename';
 
-    $tested = $parser->cleanDelimitedIdentifiers( '\''.$expected.'\'' );
+    $tested = $parser->cleanDelimitedIdentifiers('\''.$expected.'\'');
     $this->assertEquals($expected, $tested);
 
-    $tested = $parser->cleanDelimitedIdentifiers( '\''.$expected );
+    $tested = $parser->cleanDelimitedIdentifiers('\''.$expected);
     $this->assertEquals('\''.$expected, $tested);
 
-    $tested = $parser->cleanDelimitedIdentifiers( $expected.'\'' );
+    $tested = $parser->cleanDelimitedIdentifiers($expected.'\'');
     $this->assertEquals($expected.'\'', $tested);
 
     $expected = 'this is a tabl\'ename';
 
-    $tested = $parser->cleanDelimitedIdentifiers( '\''.$expected.'\'' );
+    $tested = $parser->cleanDelimitedIdentifiers('\''.$expected.'\'');
     $this->assertEquals($expected, $tested);
 
-    $tested = $parser->cleanDelimitedIdentifiers( '\''.$expected );
+    $tested = $parser->cleanDelimitedIdentifiers('\''.$expected);
     $this->assertEquals('\''.$expected, $tested);
 
-    $tested = $parser->cleanDelimitedIdentifiers( $expected.'\'' );
+    $tested = $parser->cleanDelimitedIdentifiers($expected.'\'');
     $this->assertEquals($expected.'\'', $tested);
 
     $expected = 'this is a\'tabl\'ename';
 
-    $tested = $parser->cleanDelimitedIdentifiers( '\''.$expected.'\'' );
+    $tested = $parser->cleanDelimitedIdentifiers('\''.$expected.'\'');
     $this->assertEquals($expected, $tested);
 
-    $tested = $parser->cleanDelimitedIdentifiers( '\''.$expected );
+    $tested = $parser->cleanDelimitedIdentifiers('\''.$expected);
     $this->assertEquals('\''.$expected, $tested);
 
-    $tested = $parser->cleanDelimitedIdentifiers( $expected.'\'' );
+    $tested = $parser->cleanDelimitedIdentifiers($expected.'\'');
     $this->assertEquals($expected.'\'', $tested);
 
+  }
+}
+
+class TestableMssqlSchemaParser extends MssqlSchemaParser
+{
+  public function cleanDelimitedIdentifiers($identifier)
+  {
+    return parent::cleanDelimitedIdentifiers($identifier);
   }
 }


### PR DESCRIPTION
...on mssql

I found this page : http://msdn.microsoft.com/library/ms175874.aspx
But hey are talking about " and [] delimitation, not '...

So I decide to clean only simple quote for my case.
