### PR TITLE
Fixed setting PK on new child objects of concrete-inheritance

### DIFF
--- a/test/fixtures/bookstore/behavior-concrete-inheritance-schema.xml
+++ b/test/fixtures/bookstore/behavior-concrete-inheritance-schema.xml
@@ -6,7 +6,7 @@
 		<column name="name" type="VARCHAR" size="100" primaryString="true" />
 	</table>
 
-	<table name="concrete_content" allowPkInsert="true">
+	<table name="concrete_content">
 		<column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
 		<column name="title" type="VARCHAR" size="100" primaryString="true" />
 		<column name="category_id" required="false" type="INTEGER" />

--- a/test/testsuite/generator/behavior/concrete_inheritance/ConcreteInheritanceBehaviorTest.php
+++ b/test/testsuite/generator/behavior/concrete_inheritance/ConcreteInheritanceBehaviorTest.php
@@ -10,6 +10,10 @@
  */
 
 require_once dirname(__FILE__) . '/../../../../tools/helpers/bookstore/BookstoreTestBase.php';
+require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
+require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
+require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/concrete_inheritance/ConcreteInheritanceBehavior.php';
+
 
 /**
  * Tests for ConcreteInheritanceBehavior class
@@ -20,6 +24,35 @@ require_once dirname(__FILE__) . '/../../../../tools/helpers/bookstore/Bookstore
  */
 class ConcreteInheritanceBehaviorTest extends BookstoreTestBase
 {
+	public function setUp()
+	{
+		parent::setUp();
+		
+		if (!class_exists('ConcreteContentSetPkQuery')) {
+			$schema = <<<EOF
+<database name="concrete_content_set_pk">
+	<table name="concrete_content_set_pk" allowPkInsert="true">
+		<column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
+		<column name="title" type="VARCHAR" size="100" primaryString="true" />
+		<index>
+			<index-column name="title" />
+		</index>
+
+	</table>
+	<table name="concrete_article_set_pk" allowPkInsert="true">
+		<column name="body" type="longvarchar" />
+		<column name="author_id" required="false" type="INTEGER" />
+		<behavior name="concrete_inheritance">
+			<parameter name="extends" value="concrete_content_set_pk" />
+		</behavior>
+	</table>
+</database>
+EOF;
+
+			PropelQuickBuilder::buildSchema($schema);
+		}
+	}
+	
 	public function testParentBehavior()
 	{
 		$behaviors = ConcreteContentPeer::getTableMap()->getBehaviors();
@@ -172,20 +205,6 @@ class ConcreteInheritanceBehaviorTest extends BookstoreTestBase
 		$this->assertTrue($content->isNew(), 'getParentOrCreate() returns a new instance of the parent class if the object is new');
 		$this->assertEquals('ConcreteArticle', $content->getDescendantClass(), 'getParentOrCreate() correctly sets the descendant_class of the parent object');
 	}
-	
-	public function testGetParentOrCreateNewWithPK()
-	{
-		ConcreteContentQuery::create()->deleteAll();
-		ConcreteArticleQuery::create()->deleteAll();
-		$article = new ConcreteArticle();
-		$article->setId(5);
-		$content = $article->getParentOrCreate();
-		$this->assertEquals(5, $article->getId(), 'getParentOrCreate() keeps manually set pk');
-		$this->assertTrue($content instanceof ConcreteContent, 'getParentOrCreate() returns an instance of the parent class');
-		$this->assertTrue($content->isNew(), 'getParentOrCreate() returns a new instance of the parent class if the object is new');
-		$this->assertEquals(5,$content->getId(), 'getParentOrCreate() returns a instance of the parent class with pk set');
-		$this->assertEquals('ConcreteArticle', $content->getDescendantClass(), 'getParentOrCreate() correctly sets the descendant_class of the parent object');
-	}
 
 	public function testGetParentOrCreateExisting()
 	{
@@ -241,20 +260,51 @@ class ConcreteInheritanceBehaviorTest extends BookstoreTestBase
     $this->assertNull(ConcreteContentQuery::create()->findPk($id), 'delete() removes the parent record as well');
 	}
 	
+	public function testGetParentOrCreateNewWithPK()
+	{
+		ConcreteContentSetPkQuery::create()->deleteAll();
+		ConcreteArticleSetPkQuery::create()->deleteAll();
+		$article = new ConcreteArticleSetPk();
+		$article->setId(5);
+		$content = $article->getParentOrCreate();
+		$this->assertEquals(5, $article->getId(), 'getParentOrCreate() keeps manually set pk');
+		$this->assertTrue($content instanceof ConcreteContentSetPk, 'getParentOrCreate() returns an instance of the parent class');
+		$this->assertTrue($content->isNew(), 'getParentOrCreate() returns a new instance of the parent class if the object is new');
+		$this->assertEquals(5,$content->getId(), 'getParentOrCreate() returns a instance of the parent class with pk set');
+		$this->assertEquals('ConcreteArticleSetPk', $content->getDescendantClass(), 'getParentOrCreate() correctly sets the descendant_class of the parent object');
+	}
+	
 	public function testSetPKOnNewObject()
 	{
-		ConcreteContentQuery::create()->deleteAll();
-		ConcreteArticleQuery::create()->deleteAll();
-		$article = new ConcreteArticle();
+		ConcreteContentSetPkQuery::create()->deleteAll();
+		ConcreteArticleSetPkQuery::create()->deleteAll();
+		$article = new ConcreteArticleSetPk();
 		$article->setId(2);
 		$article->save();
 		$this->assertEquals(2, $article->getId(), 'getParentOrCreate() keeps manually set pk after save');
-		$this->assertEquals(1, ConcreteContentQuery::create()->count(), 'getParentOrCreate() creates a parent entry');
-		$articledb = ConcreteArticleQuery::create()->findOneById(2);
+		$this->assertEquals(1, ConcreteContentSetPkQuery::create()->count(), 'getParentOrCreate() creates a parent entry');
+		$articledb = ConcreteArticleSetPkQuery::create()->findOneById(2);
 		$this->assertEquals(2, $articledb->getId(), 'getParentOrCreate() keeps manually set pk after save and reload from db');
 	}
 	
 	public function testSetPKOnNewObjectWithPkAlreadyInParentTable()
+	{
+		ConcreteContentSetPkQuery::create()->deleteAll();
+		ConcreteArticleSetPkQuery::create()->deleteAll();
+		try {
+			$article = new ConcreteArticleSetPk();
+			$article->setId(4);
+			$article->save();
+			$article = new ConcreteArticleSetPk();
+			$article->setId(4);
+			$article->save();
+			$this->fail('getParentOrCreate() returns a new parent object on new child objects with pk set');
+		} catch (PropelException $e) {
+			$this->assertTrue(true, 'getParentOrCreate() returns a new parent object on new child objects with pk set');
+		}
+	}
+	
+	public function testSetPkAllowPkInsertIsFalse()
 	{
 		ConcreteContentQuery::create()->deleteAll();
 		ConcreteArticleQuery::create()->deleteAll();
@@ -262,12 +312,9 @@ class ConcreteInheritanceBehaviorTest extends BookstoreTestBase
 			$article = new ConcreteArticle();
 			$article->setId(4);
 			$article->save();
-			$article = new ConcreteArticle();
-			$article->setId(4);
-			$article->save();
-			$this->fail('getParentOrCreate() returns a new parent object on new child objects with pk set');
+			$this->fail('SetPk fails when allowPkInsert is false');
 		} catch (PropelException $e) {
-			$this->assertTrue(true, 'getParentOrCreate() returns a new parent object on new child objects with pk set');
+			$this->assertTrue(true, 'SetPk fails when allowPkInsert is false');
 		}
 	}
 


### PR DESCRIPTION
Hi,

I'm using a schema that has concrete-inheritance on some tables and found a problem when setting PK on child objects:

$child = new Child();
$child->setId($id);
$child->save() // This gives a fatal php exception

I would expect Propel to automatically create parent object but it does not. I digged into concrete-inheritance behaviour and found the problem was on getParentOrCreate method.

From my point of view this is a bug so I wrote a patch to solve it and two unit tests to prove the problem and the fix.

Regards,

Pablo Gómez
