### PR TITLE
Updates to PropelMigrationTask to better handle multiple datasources.

### DIFF
--- a/generator/lib/task/PropelMigrationTask.php
+++ b/generator/lib/task/PropelMigrationTask.php
@@ -84,6 +84,11 @@ class PropelMigrationTask extends BasePropelMigrationTask
 					count($statements),
 					$datasource
 				));
+			}
+
+			// migrations for datasources have passed - update the timestamp
+			// for all datasources
+			foreach ($manager->getConnections() as $datasource => $connection) {
 				$manager->updateLatestMigrationTimestamp($datasource, $timestamp);
 				$this->log(sprintf(
 					'Updated latest migration date to %d for datasource "%s"',


### PR DESCRIPTION
- Moves updating of the timestamp out of the main migration loop per datasource. Timestamps will now only get updated when all SQL on all datasources pass and it doesn't exit out prior with false.
- Fixes issue where migrations that only specify change to one datasource don't update the timestamp in all other datasources. This caused issues when running new migrations since it will always start with the lowest migration of all the datasources.
