### PR TITLE
Handle FQCN, detect if a class' name starts with a backslash

### DIFF
--- a/generator/lib/builder/om/OMBuilder.php
+++ b/generator/lib/builder/om/OMBuilder.php
@@ -242,8 +242,17 @@ abstract class OMBuilder extends DataModelBuilder
 		foreach ($declaredClasses as $namespace => $classes) {
 			sort($classes);
 			foreach ($classes as $class) {
-				$script .= sprintf("use %s\\%s;
+				/** 
+				 * If the class' name starts with a backslash "\"" we assume it's a FQCN we are dealing with
+				 * and we don't prefix the class' name with the namespace
+				 */
+				if ('\\' === $class[0]) {
+					$script .= sprintf("use %s;
+", substr($class, 1));
+				} else {
+					$script .= sprintf("use %s\\%s;
 ", $namespace, $class);
+				}
 			}
 		}
 		return $script;


### PR DESCRIPTION
I ran into an "issue" when I was writing a behavior. Basically, what I wanted to do is making my class implementing a specific interface. As this interface wasn't in the "*\Model" namespace (and I didn't want to put it there) the behavior of the OMBuilder::getUseStatements() method didn't really suit me, I changed it a bit.

Let me know what you think :)
