### PR TITLE
Fix for Issue #222: aggregate_column behavior doesn't work for multiple aggregates

### DIFF
--- a/generator/lib/behavior/aggregate_column/templates/objectUpdateRelated.php
+++ b/generator/lib/behavior/aggregate_column/templates/objectUpdateRelated.php
@@ -4,13 +4,13 @@
  *
  * @param PropelPDO $con A connection object
  */
-protected function updateRelated<?php echo $relationName ?>(PropelPDO $con)
+protected function updateRelated<?php echo $relationName ?>For<?php echo $aggregateColumn ?>(PropelPDO $con)
 {
 	if ($<?php echo $variableName ?> = $this->get<?php echo $relationName ?>()) {
 		$<?php echo $variableName ?>-><?php echo $updateMethodName ?>($con);
 	}
-	if ($this->old<?php echo $relationName ?>) {
-		$this->old<?php echo $relationName ?>-><?php echo $updateMethodName ?>($con);
-		$this->old<?php echo $relationName ?> = null;
+	if ($this->old<?php echo $relationName ?>For<?php echo $aggregateColumn ?>) {
+		$this->old<?php echo $relationName ?>For<?php echo $aggregateColumn ?>-><?php echo $updateMethodName ?>($con);
+		$this->old<?php echo $relationName ?>For<?php echo $aggregateColumn ?> = null;
 	}
 }

--- a/generator/lib/behavior/aggregate_column/templates/queryFindRelated.php
+++ b/generator/lib/behavior/aggregate_column/templates/queryFindRelated.php
@@ -4,7 +4,7 @@
  *
  * @param PropelPDO $con A connection object
  */
-protected function findRelated<?php echo $relationName ?>s($con)
+protected function findRelated<?php echo $relationName ?>s<?php echo $aggregateColumn ?>($con)
 {
 	$criteria = clone $this;
 	if ($this->useAliasInSQL) {

--- a/generator/lib/behavior/aggregate_column/templates/queryUpdateRelated.php
+++ b/generator/lib/behavior/aggregate_column/templates/queryUpdateRelated.php
@@ -1,5 +1,5 @@
 
-protected function updateRelated<?php echo $relationName ?>s($con)
+protected function updateRelated<?php echo $relationName ?>s<?php echo $aggregateColumn ?>($con)
 {
 	foreach ($this-><?php echo $variableName ?>s as $<?php echo $variableName ?>) {
 		$<?php echo $variableName ?>-><?php echo $updateMethodName ?>($con);


### PR DESCRIPTION
Ref: http://github.com/propelorm/Propel/issues/222
Propel does not support multiple behaviors of the same name on the same table. Therefore multiple aggregates are specified as a comma separated string.
e.g.
`<behavior name="aggregate_column">`
`<parameter name="name" value="nb_products, total_quantity" />`
`<parameter name="foreign_table" value="store_product, store_product" />`
`<parameter name="expression" value="COUNT(product_id), SUM(quantity)" />`
`</behavior>`
