### PR TITLE
aggregate_column & concrete_inheritance bugfixes

### DIFF
--- a/generator/lib/behavior/aggregate_column/AggregateColumnBehavior.php
+++ b/generator/lib/behavior/aggregate_column/AggregateColumnBehavior.php
@@ -120,7 +120,15 @@ class AggregateColumnBehavior extends Behavior
         // let's infer the relation from the foreign table
         $fks = $foreignTable->getForeignKeysReferencingTable($this->getTable()->getName());
         if (!$fks) {
-            throw new InvalidArgumentException(sprintf('You must define a foreign key to the \'%s\' table in the \'%s\' table to enable the \'aggregate_column\' behavior', $this->getTable()->getName(), $foreignTable->getName()));
+            foreach ($this->getTable()->getBehaviors() as $behavior) {
+                if ($behavior->getName() != 'concrete_inheritance') continue;
+                $fks = $foreignTable->getForeignKeysReferencingTable($behavior->getParentTable()->getName());
+                if ($fks) break;
+            }
+            
+            if (!$fks) {
+                throw new InvalidArgumentException(sprintf('You must define a foreign key to the \'%s\' table in the \'%s\' table to enable the \'aggregate_column\' behavior', $this->getTable()->getName(), $foreignTable->getName()));
+            }
         }
         // FIXME doesn't work when more than one fk to the same table
         return array_shift($fks);

--- a/generator/lib/behavior/aggregate_column/AggregateColumnRelationBehavior.php
+++ b/generator/lib/behavior/aggregate_column/AggregateColumnRelationBehavior.php
@@ -65,9 +65,9 @@ class AggregateColumnRelationBehavior extends Behavior
     {
         $relationName = $this->getRelationName($builder);
         $relatedClass = $this->getForeignTable()->getPhpName();
-		$search = "public function set{$relationName}({$relatedClass} \$v = null)
+        $search = "public function set{$relationName}({$relatedClass} \$v = null)
     {";
-		$replace = $search . "
+        $replace = $search . "
         // aggregate_column_relation behavior
         if (null !== \$this->a{$relationName} && \$v !== \$this->a{$relationName}) {
             \$this->old{$relationName} = \$this->a{$relationName};
@@ -155,6 +155,13 @@ class AggregateColumnRelationBehavior extends Behavior
         $foreignTable = $this->getForeignTable();
         // let's infer the relation from the foreign table
         $fks = $this->getTable()->getForeignKeysReferencingTable($foreignTable->getName());
+        if (!$fks) {
+            foreach ($foreignTable->getBehaviors() as $behavior) {
+                if ($behavior->getName() != 'concrete_inheritance') continue;
+                $fks = $this->getTable()->getForeignKeysReferencingTable($behavior->getParentTable()->getName());
+                if ($fks) break;
+            }
+        }
         // FIXME doesn't work when more than one fk to the same table
         return array_shift($fks);
     }


### PR DESCRIPTION
- Enabled aggregate_column in combination with concrete_inheritance, if the foreign key of the referenced table is in the child table.
- Added preemptive error handling for concrete_inheritance, if the flag copy_data_from_parent is set and the primary keys have the same name in the parent and in the child table. In this situation you can't (easily) copy the foreign key from the parent. This wasn't made because same named columns are completely ignored, but there was no error handling for the situation. So a wrong schema could be build without this fix. But at runtime, the wrong schema had caused a lack of the method like get[ParentClassName], which will be called by getOrCreateParent(). This needs definitively further investigation.
