### PR TITLE
Add support for composer's bin-property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,6 @@
     "branch-alias": {
       "dev-master": "1.6-dev"
     }
-  }
+  },
+  "bin": ["generator/bin/propel-gen", "generator/bin/propel-gen.bat"]
 }


### PR DESCRIPTION
Composer has added support for bin-files, making it easier to find bind-files in a project from various dependencies. Adding this would make it more convenient to access the bin-file in the propel's generator directory.

More info can be found about the "bin" property at: http://getcomposer.org/doc/articles/vendor-bins.md

The only thing I'm unsure about is the propel-gen.bat which composer notes that it already has automatic support for on windows, and I also see a "phing.php" in the bin folder (but I guess that one should come from the phing composer project, and not propel).
