### PR TITLE
Joins on self referring classes

### DIFF
--- a/test/fixtures/bookstore/runtime-conf.xml
+++ b/test/fixtures/bookstore/runtime-conf.xml
@@ -91,6 +91,28 @@
 				</connection>
 			</datasource>
 
+			<datasource id="bookstore-selfreferring">
+				<adapter>mysql</adapter>
+				<connection>
+					<classname>DebugPDO</classname>
+					<dsn>mysql:dbname=test</dsn>
+					<!--
+					For MySQL and Oracle you must specify username + password separate from DSN:
+					-->
+					<user>root</user>
+					<password></password>
+					<options>
+						<option id="ATTR_PERSISTENT">false</option>
+					</options>
+					<attributes>
+						<option id="ATTR_EMULATE_PREPARES">true</option>
+					</attributes>
+					<settings>
+						<setting id="charset">utf8</setting>
+					</settings>
+				</connection>
+			</datasource>
+
 		</datasources>
 	</propel>
 </config>

--- a/test/fixtures/bookstore/selfreferring-schema.xml
+++ b/test/fixtures/bookstore/selfreferring-schema.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<database name="bookstore-selfreferring" defaultIdMethod="native" package="selfreferring">
+
+  <table name="self_referring">
+    <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true" />
+    <column name="related_id" type="integer" required="false" />
+    <foreign-key foreignTable="self_referring" onDelete="set null">
+      <reference local="related_id" foreign="id" />
+    </foreign-key>
+    <column name="name" type="varchar" required="true" size="255" />
+  </table>
+
+</database>

--- a/test/testsuite/misc/SelfReferringTest.php
+++ b/test/testsuite/misc/SelfReferringTest.php
@@ -1,0 +1,66 @@
+<?php
+require_once dirname(__FILE__) . '/../../../runtime/lib/Propel.php';
+set_include_path(get_include_path() . PATH_SEPARATOR . realpath(dirname(__FILE__) . '/../../fixtures/bookstore/build/classes'));
+Propel::init(dirname(__FILE__) . '/../../fixtures/bookstore/build/conf/bookstore-conf.php');
+
+
+class SelfReferringTest extends PHPUnit_Framework_TestCase
+{
+    public static $con;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        // Get the Connection
+        self::$con = Propel::getConnection(SelfReferringPeer::DATABASE_NAME);
+
+        $item = new SelfReferring();
+        $item->setName('Item');
+
+        $item2 = new SelfReferring();
+        $item2->setName('Item2');
+        $item2->setSelfReferringRelatedByRelatedId($item);
+
+        $item->save();
+    }
+
+
+    public static function tearDownAfterClass()
+    {
+      // Cleanup the Database
+      call_user_func(array('SelfReferringPeer', 'doDeleteAll'), self::$con);
+      parent::tearDownAfterClass();
+    }
+
+    public function testBasicQuery()
+    {
+      $results = SelfReferringQuery::create()
+        ->filterByName('Item')
+        ->findOne();
+    }
+
+    public function testBasicQueryWithLeftJoin()
+    {
+      $results = SelfReferringQuery::create()
+        ->where('Name', 'Item')
+        ->leftJoinSelfReferringRelatedByRelatedId()
+        ->findOne();
+    }
+
+    public function testBasicQueryWithNamedLeftJoin()
+    {
+      $results = SelfReferringQuery::create()
+        ->filterByName('Item')
+        ->leftJoinSelfReferringRelatedByRelatedId('self_referring2')
+        ->findOne();
+    }
+
+    public function testBasicQueryWithNamedLeftJoinAndInlusionOfRelatedObject()
+    {
+      $results = SelfReferringQuery::create()
+        ->filterByName('Item')
+        ->leftJoinWithSelfReferringRelatedByRelatedId('self_referring2')
+        ->findOne();
+    }
+}


### PR DESCRIPTION
Hi,

I've found a bug where joins on self referring classes do not work correctly using queries. The generated SQL is wrong.

Here a snippet from the test output:

```
$ phpunit test/testsuite/misc/SelfReferringTest

[...]

.E.E

Time: 0 seconds, Memory: 8.25Mb

There were 2 errors:

1) SelfReferringTest::testBasicQueryWithLeftJoin
PropelException: Unable to execute SELECT statement [SELECT self_referring.ID, self_referring.RELATED_ID, self_referring.NAME FROM  LEFT JOIN `self_referring` ON (self_referring.RELATED_ID=self_referring.ID) WHERE Name LIMIT 1] [wrapped: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'LEFT JOIN `self_referring` ON (self_referring.RELATED_ID=self_referring.ID) WHER' at line 1]

[...]

2) SelfReferringTest::testBasicQueryWithNamedLeftJoinAndInlusionOfRelatedObject
PropelException: Unable to execute SELECT statement [SELECT self_referring.ID, self_referring.RELATED_ID, self_referring.NAME, self_referring.ID, self_referring.RELATED_ID, self_referring.NAME FROM  LEFT JOIN `self_referring` ON (self_referring.RELATED_ID=self_referring.ID) WHERE self_referring.NAME=:p1 LIMIT 1] [wrapped: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'LEFT JOIN `self_referring` ON (self_referring.RELATED_ID=self_referring.ID) WHER' at line 1]

[...]

FAILURES!
Tests: 4, Assertions: 0, Errors: 2.
```
