### PR TITLE
Preventing exception at runtime when getting TableMap of foreign key in ColumnMap

### DIFF
--- a/runtime/lib/map/ColumnMap.php
+++ b/runtime/lib/map/ColumnMap.php
@@ -390,7 +390,7 @@ class ColumnMap
   public function getRelatedTable()
   {
     if ($this->relatedTableName) {
-      return $this->table->getDatabaseMap()->getTable($this->relatedTableName);
+      return $this->getRelation()->getForeignTable();
     } else {
       throw new PropelException("Cannot fetch RelatedTable for column with no foreign key: " . $this->columnName);
     }


### PR DESCRIPTION
As seen with Willdurand in the following discussion:
https://github.com/propelorm/Propel/commit/e17d34bc563230793bf0d138849febcc6cbfdd19#commitcomment-1445920
See commit for more details
