### PR TITLE
Fix for using platform class configured in build properties

### DIFF
--- a/generator/lib/config/GeneratorConfig.php
+++ b/generator/lib/config/GeneratorConfig.php
@@ -156,11 +156,11 @@ class GeneratorConfig implements GeneratorConfigInterface
     public function getConfiguredPlatform(PDO $con = null, $database = null)
     {
         $buildConnection = $this->getBuildConnection($database);
-        if (null !== $buildConnection['adapter']) {
-            $clazz = Phing::import('platform.' . ucfirst($buildConnection['adapter']) . 'Platform');
-        } elseif ($this->getBuildProperty('platformClass')) {
+        if ($this->getBuildProperty('platformClass')) {
             // propel.platform.class = platform.${propel.database}Platform by default
             $clazz = $this->getClassname('platformClass');
+        } elseif (null !== $buildConnection['adapter']) {
+            $clazz = Phing::import('platform.' . ucfirst($buildConnection['adapter']) . 'Platform');
         } else {
             return null;
         }


### PR DESCRIPTION
In documentation stated, that i can specify my own platform class like this

```
# Platform classes
propel.platform.class = platform.${propel.database}Platform
```

This change fixes getConfiguredPlatform function to use platform from build properties, if specified
