### PR TITLE
allow chaining of keyColumns in PropelObjectCollection::toKeyValue

### DIFF
--- a/runtime/lib/collection/PropelObjectCollection.php
+++ b/runtime/lib/collection/PropelObjectCollection.php
@@ -211,8 +211,11 @@ class PropelObjectCollection extends PropelCollection
      * <code>
      *   $res = $coll->toKeyValue('Id', 'Name');
      * </code>
+     * <code>
+     *   $res = $coll->toKeyValue(array('RelatedModel', 'Name'), 'Name');
+     * </code>
      *
-     * @param string $keyColumn
+     * @param string|array $keyColumn The name of the column, or a list of columns to call.
      * @param string $valueColumn
      *
      * @return array
@@ -220,13 +223,39 @@ class PropelObjectCollection extends PropelCollection
     public function toKeyValue($keyColumn = 'PrimaryKey', $valueColumn = null)
     {
         $ret = array();
-        $keyGetterMethod = 'get' . $keyColumn;
         $valueGetterMethod = (null === $valueColumn) ? '__toString' : ('get' . $valueColumn);
+
+        if (!is_array($keyColumn)) {
+            $keyColumn = array($keyColumn);
+        }
+
         foreach ($this as $obj) {
-            $ret[$obj->$keyGetterMethod()] = $obj->$valueGetterMethod();
+            $ret[$this->getValueForColumns($obj, $keyColumn)] = $obj->$valueGetterMethod();
         }
 
         return $ret;
+    }
+
+    /**
+     * Return the value for a given set of key columns.
+     *
+     * Each column will be resolved on the value returned by the previous one.
+     *
+     * @param object $object  The object to start with.
+     * @param array  $columns The sequence of key columns.
+     *
+     * @return mixed
+     */
+    protected function getValueForColumns($object, array $columns)
+    {
+        $value = $object;
+
+        foreach ($columns as $eachKeyColumn) {
+            $keyGetterMethod = 'get'.$eachKeyColumn;
+            $value = $value->$keyGetterMethod();
+        }
+
+        return $value;
     }
 
     /**

--- a/test/testsuite/runtime/collection/PropelObjectCollectionTest.php
+++ b/test/testsuite/runtime/collection/PropelObjectCollectionTest.php
@@ -139,4 +139,35 @@ class PropelObjectCollectionTest extends BookstoreTestBase
         $this->assertEquals(0, $author->countBooks());
         $this->assertEquals($count, $this->con->getQueryCount());
     }
+
+    public function testToKeyValue()
+    {
+        $author = new Author();
+        $author->setId(5678);
+        $author->setFirstName('George');
+        $author->setLastName('Byron');
+
+        $book = new Book();
+        $book->setId(9012);
+        $book->setTitle('Don Juan');
+        $book->setISBN('0140422161');
+        $book->setPrice(12.99);
+        $book->setAuthor($author);
+
+        $coll = new PropelObjectCollection();
+        $coll->setModel('Book');
+        $coll->append($book);
+
+        $this->assertCount(1, $coll);
+
+        // This will call $book->getId()
+        $this->assertEquals(array(
+            9012 => 'Don Juan',
+        ), $coll->toKeyValue('Id', 'Title'));
+
+        // This will call: $book->getAuthor()->getBooks()->getFirst()->getId()
+        $this->assertEquals(array(
+            9012 => 'Don Juan',
+        ), $coll->toKeyValue(array('Author', 'Books', 'First', 'Id'), 'Title'));
+    }
 }


### PR DESCRIPTION
We got the following use-case, where this is comes in very handy.

We have a user profile and a list of available attributes.
The profile has a list of entries of which each relates to one attribute and a value on the respective profile.

With this patch, a call like `$this->getEntriesJoinAttribute()->toKeyValue(array('Attribute', 'Ident'), 'Value')` yields a key value for attribute identifier to value.

```
array(size=3)
  'COMPANY_NAME' =>string'Ormigo GmbH'(length=11)
  'FIRSTNAME' =>string'Toni'(length=4)
  'PROFILE_PHOTO' =>string'c4ca4238a0b923820dcc509a6f75849b.jpeg'(length=37)
```
