### PR TITLE
Updated the Table class to not use the schema prefix as part of the phpName

### DIFF
--- a/generator/lib/model/Table.php
+++ b/generator/lib/model/Table.php
@@ -83,11 +83,18 @@ class Table extends ScopedElement implements IDMethod
     private $idMethodParameters = array();
 
     /**
-     * Table name.
+     * Table name (with prefix if it has one).
      *
      * @var       string
      */
     private $commonName;
+    
+    /**
+     * Table name without prefix.  Only used for phpName generation.
+     * 
+     * @var       string
+     */
+    private $nonPrefixedName;
 
     /**
      * Table description.
@@ -302,6 +309,7 @@ class Table extends ScopedElement implements IDMethod
     public function __construct($name = null)
     {
         $this->commonName = $name;
+        $this->nonPrefixedName = $name;
     }
 
     /**
@@ -312,9 +320,9 @@ class Table extends ScopedElement implements IDMethod
     private function getStdSeparatedName()
     {
         if ($this->schema && $this->getBuildProperty('schemaAutoPrefix')) {
-            return $this->schema . NameGenerator::STD_SEPARATOR_CHAR . $this->getCommonName();
+            return $this->schema . NameGenerator::STD_SEPARATOR_CHAR . $this->nonPrefixedName;
         } else {
-            return $this->getCommonName();
+            return $this->nonPrefixedName;
         }
     }
 
@@ -326,6 +334,7 @@ class Table extends ScopedElement implements IDMethod
     {
         parent::setupObject();
         $this->commonName = $this->getDatabase()->getTablePrefix() . $this->getAttribute("name");
+        $this->nonPrefixedName = $this->getAttribute('name');
 
         // retrieves the method for converting from specified name to a PHP name.
         $this->phpNamingMethod = $this->getAttribute("phpNamingMethod", $this->getDatabase()->getDefaultPhpNamingMethod());

--- a/test/testsuite/generator/behavior/DelegateBehaviorTest.php
+++ b/test/testsuite/generator/behavior/DelegateBehaviorTest.php
@@ -258,10 +258,10 @@ EOF;
 </database>
 EOF;
         PropelQuickBuilder::buildSchema($schema);
-        $main = new FooTestTablePrefixSameDatabaseMain();
+        $main = new TestTablePrefixSameDatabaseMain();
         $main->setSubtitle('bar');
-        $delegate = $main->getFooTestTablePrefixSameDatabaseDelegate();
-        $this->assertInstanceOf('FooTestTablePrefixSameDatabaseDelegate', $delegate);
+        $delegate = $main->getTestTablePrefixSameDatabaseDelegate();
+        $this->assertInstanceOf('TestTablePrefixSameDatabaseDelegate', $delegate);
         $this->assertTrue($delegate->isNew());
         $this->assertEquals('bar', $delegate->getSubtitle());
         $this->assertEquals('bar', $main->getSubtitle());

--- a/test/testsuite/generator/model/TableTest.php
+++ b/test/testsuite/generator/model/TableTest.php
@@ -468,4 +468,20 @@ EOF;
         $table3 = $db->getTable("table_is_cross_ref_false");
         $this->assertFalse($table3->getIsCrossRef());
     }
+    
+    public function testPrefixDoesntAffectPhpName () {
+        $xmlToAppData = new XmlToAppData();
+        $schema = <<<EOF
+<database name="test1" tablePrefix="pf_">
+  <table name="table1">
+    <column name="id" type="INTEGER" primaryKey="true" />
+  </table>
+</database>
+EOF;
+        $appData = $xmlToAppData->parseString($schema); 
+        
+        $table = $appData->getDatabase('test1')->getTable('pf_table1');
+        
+        $this->assertEquals('Table1', $table->getPhpName());
+    }
 }


### PR DESCRIPTION
Fixes issue #5.  Changed DelegateBehaviorTest to not use the backwards-incompatible phpName.
