### PR TITLE
Abstract static method replaced by a runtime exception in *Peer

### DIFF
--- a/generator/lib/builder/om/PHP5PeerBuilder.php
+++ b/generator/lib/builder/om/PHP5PeerBuilder.php
@@ -1312,7 +1312,9 @@ abstract class ".$this->getClassname(). $extendingPeerClass . "
      * This method must be overridden by the stub subclass, because
      * ".$this->getObjectClassname()." is declared abstract in the schema.
      */
-    abstract public static function getOMClass();
+    public static function getOMClass() {
+        throw new \\LogicException(\"You can't get OMClass for an abstract Peer class.\");
+    }
 ";
     }
 


### PR DESCRIPTION
According to strict PHP standards with PHP 5.2 and more, abstract static
functions are not allowed.

This post on Stack Overflow summarize main points about this topic:
http://stackoverflow.com/questions/999066/why-does-php-5-2-disallow-abstract-static-class-methods
