### PR TITLE
Ignore composer.phar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/fixtures/schemas/build/
 test/fixtures/treetest/build/
 vendor/
 composer.lock
+composer.phar


### PR DESCRIPTION
Composer.phar is needed for tests, but shouldn't be commited
