### PR TITLE
Make findOneById to be an alias of findPk

### DIFF
--- a/generator/lib/builder/om/QueryBuilder.php
+++ b/generator/lib/builder/om/QueryBuilder.php
@@ -186,6 +186,7 @@ abstract class ".$this->getClassname()." extends " . $parentClass . "
         $this->addConstructor($script);
         $this->addFactory($script);
         $this->addFindPk($script);
+        $this->addFindOneByPk($script);
         $this->addFindPkSimple($script);
         $this->addFindPkComplex($script);
         $this->addFindPks($script);
@@ -439,6 +440,34 @@ abstract class ".$this->getClassname()." extends " . $parentClass . "
             return \$this->findPkSimple(\$key, \$con);
         }
     }
+";
+    }
+
+    protected function addFindOneByPk(&$script)
+    {
+        $table = $this->getTable();
+        if ($table->hasCompositePrimaryKey()) {
+            return;
+        }
+
+        $pk = $table->getPrimaryKey();
+        $column = $pk[0]->getPhpName();
+        $ARClassname = $this->getObjectClassname();
+
+        $script .= "
+    /**
+     * Alias of findPk to use instance pooling
+     *
+     * @param     mixed \$key Primary key to use for the query
+     * @param     PropelPDO \$con A connection object
+     *
+     * @return   $ARClassname A model object, or null if the key is not found
+     * @throws   PropelException
+     */
+     public function findOneBy{$column}(\$key, \$con = null)
+     {
+        return \$this->findPk(\$key, \$con);
+     }
 ";
     }
 

--- a/test/testsuite/generator/builder/om/QueryBuilderTest.php
+++ b/test/testsuite/generator/builder/om/QueryBuilderTest.php
@@ -128,6 +128,12 @@ class QueryBuilderTest extends BookstoreTestBase
         $this->assertEquals('BaseTable4Query', $method->getDeclaringClass()->getName(), 'BaseQuery overrides findPk()');
     }
 
+    public function testFindOneById()
+    {
+        $method = new ReflectionMethod('Table4Query', 'findOneById');
+        $this->assertEquals('BaseTable4Query', $method->getDeclaringClass()->getName(), 'BaseQuery overrides findOneById()');
+    }
+
     public function testFindPkReturnsCorrectObjectForSimplePrimaryKey()
     {
         $b = new Book();
@@ -196,6 +202,21 @@ class QueryBuilderTest extends BookstoreTestBase
         $count = $this->con->getQueryCount();
 
         $book = BookQuery::create()->findPk($b->getId(), $this->con);
+        $this->assertEquals($b, $book);
+        $this->assertEquals($count, $this->con->getQueryCount());
+    }
+
+    public function testFindOneByIdAddsObjectToInstancePool()
+    {
+        $b = new Book();
+        $b->setTitle('foo');
+        $b->save($this->con);
+        BookPeer::clearInstancePool();
+
+        BookQuery::create()->findOneById($b->getId(), $this->con);
+        $count = $this->con->getQueryCount();
+
+        $book = BookQuery::create()->findOneById($b->getId(), $this->con);
         $this->assertEquals($b, $book);
         $this->assertEquals($count, $this->con->getQueryCount());
     }


### PR DESCRIPTION
Only for non composite pk. This permit to use instancePooling when user use findOneById instead of findPk

cc @fzaninotto
