### PR TITLE
postHydrate hook

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -2053,7 +2053,11 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
             if (\$rehydrate) {
                 \$this->ensureConsistency();
             }
+            \$this->postHydrate(\$row, \$startcol, \$rehydrate);";
+        
+        $this->applyBehaviorModifier('postHydrate', $script, "            ");
 
+        $script .= "
             return \$startcol + $n; // $n = ".$this->getPeerClassname()."::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception \$e) {

--- a/runtime/lib/om/BaseObject.php
+++ b/runtime/lib/om/BaseObject.php
@@ -208,6 +208,14 @@ abstract class BaseObject
     }
 
     /**
+     * Code to be run after deleting the object in database
+     * @param PropelPDO $con
+     */
+    public function postHydrate($row, $startcol = 0, $rehydrate = false)
+    {
+    }
+    
+    /**
      * Sets the modified state for the object to be false.
      * @param      string $col If supplied, only the specified column is reset.
      * @return     void

--- a/test/testsuite/generator/behavior/ObjectBehaviorTest.php
+++ b/test/testsuite/generator/behavior/ObjectBehaviorTest.php
@@ -129,6 +129,16 @@ class ObjectBehaviorTest extends BookstoreTestBase
     $this->assertEquals($t->postDeleteBuilder, 'PHP5ObjectBuilder', 'postDelete hook is called with the object builder as parameter');
     $this->assertFalse($t->postDeleteIsBeforeDelete, 'postDelete hook is called before deletion');
   }
+  
+  public function testPostHydrate()
+  {
+    $t = new Table3();
+    $t->postHydrate = 0;
+    $t->hydrate(array(1, 'Title', 'Test'));
+    $this->assertEquals($t->postHydrate, 1, 'postHydrate hook is called on object hydration');
+    $this->assertEquals($t->postHydrateBuilder, 'PHP5ObjectBuilder', 'postHydrate hook is called with the object builder as parameter');
+    $this->assertTrue($t->postHydrateIsAfterHydrate, 'postHydrate hook is called after hydrate');
+  }
 
   public function testObjectMethods()
   {

--- a/test/testsuite/generator/builder/om/GeneratedObjectTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectTest.php
@@ -1044,7 +1044,14 @@ EOF;
         $author->delete();
         $this->assertEquals("Post-Deleted", $author->getLastName());
     }
-
+    
+    public function testPostHydrate()
+    {
+        $author = new TestAuthor();
+        $author->hydrate(array(1, 'bogus', 'Lastname', 'bogus@mail.com', 21));
+        $this->assertEquals("Post-Hydrated", $author->getLastName());
+    }
+    
     public function testMagicVirtualColumnGetter()
     {
         $book = new Book();

--- a/test/tools/helpers/bookstore/behavior/TestAuthor.php
+++ b/test/tools/helpers/bookstore/behavior/TestAuthor.php
@@ -65,6 +65,12 @@ class TestAuthor extends Author
         parent::postDelete($con);
         $this->setLastName("Post-Deleted");
     }
+    
+    public function postHydrate($row, $startcol = 0, $rehydrate = false)
+    {
+        parent::postHydrate($row, $startcol, $rehydrate);
+        $this->setLastName("Post-Hydrated");
+    }
 }
 
 class TestAuthorDeleteFalse extends TestAuthor

--- a/test/tools/helpers/bookstore/behavior/Testallhooksbehavior.php
+++ b/test/tools/helpers/bookstore/behavior/Testallhooksbehavior.php
@@ -114,6 +114,11 @@ class TestAllHooksObjectBuilderModifier
   {
     return '$this->postDelete = 1;$this->postDeleteIsBeforeDelete = isset(Table3Peer::$instances[$this->id]);$this->postDeleteBuilder="' . get_class($builder) . '";';
   }
+  
+  public function postHydrate($builder)
+  {
+    return '$this->postHydrate = 1;$this->postHydrateIsAfterHydrate = isset($this->id);$this->postHydrateBuilder="' . get_class($builder) . '";';
+  }
 
   public function objectMethods($builder)
   {


### PR DESCRIPTION
Added postHydate hook to make behaviors execute after loading an object.

This makes it possible to create a propel adapter for  symfony bundles that currently only support doctrine (using doctrine's postLoad event).

(eg VichUploaderBundle)
