### PR TITLE
fix performance issue loading references on save

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -4522,7 +4522,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
                 $varName = $this->getPKRefFKVarName($refFK);
                 $script .= "
             if (\$this->$varName !== null) {
-                if (!\$this->{$varName}->isDeleted()) {
+                if (!\$this->{$varName}->isDeleted() && (\$this->{$varName}->isNew() || \$this->{$varName}->isModified())) {
                         \$affectedRows += \$this->{$varName}->save(\$con);
                 }
             }
@@ -4532,7 +4532,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
                 $script .= "
             if (\$this->$collName !== null) {
                 foreach (\$this->$collName as \$referrerFK) {
-                    if (!\$referrerFK->isDeleted()) {
+                    if (!\$referrerFK->isDeleted() && (\$referrerFK->isNew() || \$referrerFK->isModified())) {
                         \$affectedRows += \$referrerFK->save(\$con);
                     }
                 }

--- a/test/testsuite/generator/builder/om/GeneratedObjectRelTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectRelTest.php
@@ -866,4 +866,48 @@ class GeneratedObjectRelTest extends BookstoreEmptyTestBase
         $this->assertCount(1, $bookClubList->getFavoriteBookRelateds(), 'there should be one book in the bookClubList');
     }
 
+    public function testRefIsOnlySavedWhenRequired()
+    {
+        BookQuery::create()->deleteAll();
+
+        $book = new Book();
+        $book->setTitle('Propel Book');
+        $book->setISBN('TEST');
+        $book->save();
+        $bookId = $book->getId();
+
+        BookPeer::clearInstancePool();
+
+        $summary = $this->getMock('BookSummary');
+        $summary
+            ->expects($this->once())
+            ->method('isDeleted')
+            ->will($this->returnValue(false))
+        ;
+        $summary
+            ->expects($this->once())
+            ->method('isNew')
+            ->will($this->returnValue(false))
+        ;
+        $summary
+            ->expects($this->once())
+            ->method('isModified')
+            ->will($this->returnValue(false))
+        ;
+        $summary
+            ->expects($this->never())
+            ->method('save')
+        ;
+
+        $coll = new PropelObjectCollection();
+        $coll->append($summary);
+
+        $book = BookQuery::create()->findOneById($bookId);
+
+        // In conjunction with the mock above, this simulates loading those entries prior saving the book.
+        $book->setBookSummarys($coll);
+
+        $book->setTitle('Propel2 Book');
+        $book->save();
+    }
 }


### PR DESCRIPTION
This solves an issue where the database would be loaded "completely" (by traversing the references tree) in case a relation has been loaded between retrieving the object and the next update of it.
