### PR TITLE
i18nBehavior Composite Primary Key Support

### DIFF
--- a/generator/lib/behavior/i18n/I18nBehavior.php
+++ b/generator/lib/behavior/i18n/I18nBehavior.php
@@ -21,7 +21,7 @@ require_once dirname(__FILE__) . '/I18nBehaviorPeerBuilderModifier.php';
  */
 class I18nBehavior extends Behavior
 {
-    const DEFAULT_LOCALE = 'en_EN';
+    const DEFAULT_LOCALE = 'en_US';
 
     // default parameters value
     protected $parameters = array(

--- a/test/testsuite/generator/behavior/i18n/I18nBehaviorObjectBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/i18n/I18nBehaviorObjectBuilderModifierTest.php
@@ -92,7 +92,7 @@ EOF;
         I18nBehaviorTest1I18nQuery::create()->deleteAll();
         $o = new I18nBehaviorTest1();
         $o->setFoo(123);
-        $o->setLocale('en_EN');
+        $o->setLocale('en_US');
         $o->setBar('hello');
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
@@ -139,13 +139,13 @@ EOF;
     {
         $o = new I18nBehaviorTest1();
         $translation1 = new I18nBehaviorTest1I18n();
-        $translation1->setLocale('en_EN');
+        $translation1->setLocale('en_US');
         $o->addI18nBehaviorTest1I18n($translation1);
         $translation2 = new I18nBehaviorTest1I18n();
         $translation2->setLocale('fr_FR');
         $o->addI18nBehaviorTest1I18n($translation2);
         $o->save();
-        $this->assertEquals($translation1, $o->getTranslation('en_EN'));
+        $this->assertEquals($translation1, $o->getTranslation('en_US'));
         $this->assertEquals($translation2, $o->getTranslation('fr_FR'));
     }
 
@@ -154,7 +154,7 @@ EOF;
         $o = new I18nBehaviorTest1();
         $o->save();
         $translation = $o->getTranslation();
-        $this->assertEquals('en_EN', $translation->getLocale());
+        $this->assertEquals('en_US', $translation->getLocale());
         $o = new I18nBehaviorTest2();
         $o->save();
         $translation = $o->getTranslation();
@@ -165,12 +165,12 @@ EOF;
     {
         $o = new I18nBehaviorTest1();
         $translation1 = new I18nBehaviorTest1I18n();
-        $translation1->setLocale('en_EN');
+        $translation1->setLocale('en_US');
         $o->addI18nBehaviorTest1I18n($translation1);
         $translation2 = new I18nBehaviorTest1I18n();
         $translation2->setLocale('fr_FR');
         $o->addI18nBehaviorTest1I18n($translation2);
-        $translation = $o->getTranslation('en_EN');
+        $translation = $o->getTranslation('en_US');
         $this->assertEquals($translation1, $translation);
     }
 
@@ -178,7 +178,7 @@ EOF;
     {
         $o = new I18nBehaviorTest1();
         $translation1 = new I18nBehaviorTest1I18n();
-        $translation1->setLocale('en_EN');
+        $translation1->setLocale('en_US');
         $o->addI18nBehaviorTest1I18n($translation1);
         $translation2 = new I18nBehaviorTest1I18n();
         $translation2->setLocale('fr_FR');
@@ -201,7 +201,7 @@ EOF;
     public function testGetLocaleReturnsDefaultLocale()
     {
         $o = new I18nBehaviorTest1();
-        $this->assertEquals('en_EN', $o->getLocale());
+        $this->assertEquals('en_US', $o->getLocale());
         $o = new I18nBehaviorTest2();
         $this->assertEquals('fr_FR', $o->getLocale());
     }
@@ -218,7 +218,7 @@ EOF;
         $o = new I18nBehaviorTest1();
         $o->setLocale('fr_FR');
         $o->setLocale();
-        $this->assertEquals('en_EN', $o->getLocale());
+        $this->assertEquals('en_US', $o->getLocale());
     }
 
     public function testLocaleSetterAndGetterAliasesExist()
@@ -236,15 +236,15 @@ EOF;
     public function testSetLocaleAlias()
     {
         $o = new I18nBehaviorTest2();
-        $o->setCulture('en_EN');
-        $this->assertEquals('en_EN', $o->getCulture());
+        $o->setCulture('en_US');
+        $this->assertEquals('en_US', $o->getCulture());
     }
 
     public function testGetCurrentTranslationUsesDefaultLocale()
     {
         $o = new I18nBehaviorTest1();
         $t = $o->getCurrentTranslation();
-        $this->assertEquals('en_EN', $t->getLocale());
+        $this->assertEquals('en_US', $t->getLocale());
         $o = new I18nBehaviorTest2();
         $t = $o->getCurrentTranslation();
         $this->assertEquals('fr_FR', $t->getLocale());
@@ -268,7 +268,7 @@ EOF;
         $t2 = $o->getCurrentTranslation();
         $t2->setBar('bonjour');
         //$o->save();
-        $o->setLocale('en_EN');
+        $o->setLocale('en_US');
         $this->assertEquals('hello', $o->getBar());
         $o->setLocale('fr_FR');
         $this->assertEquals('bonjour', $o->getBar());
@@ -280,7 +280,7 @@ EOF;
         $o->setBar('hello');
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
-        $o->setLocale('en_EN');
+        $o->setLocale('en_US');
         $this->assertEquals('hello', $o->getBar());
         $o->setLocale('fr_FR');
         $this->assertEquals('bonjour', $o->getBar());
@@ -312,7 +312,7 @@ EOF;
         $translation1->setLocale('fr_FR');
         $o->addI18nBehaviorTest1I18n($translation1);
         $o->clear();
-        $this->assertEquals('en_EN', $o->getLocale());
+        $this->assertEquals('en_US', $o->getLocale());
         $t1 = $o->getTranslation('fr_FR');
         $this->assertEquals('', $t1->getBar());
     }
@@ -398,13 +398,13 @@ EOF;
     {
         $o = new I18nBehaviorTestLocalColumn();
         $translation1 = new I18nBehaviorTestLocalColumnI18n();
-        $translation1->setMyLang('en_EN');
+        $translation1->setMyLang('en_US');
         $o->addI18nBehaviorTestLocalColumnI18n($translation1);
         $translation2 = new I18nBehaviorTestLocalColumnI18n();
         $translation2->setMyLang('fr_FR');
         $o->addI18nBehaviorTestLocalColumnI18n($translation2);
         $o->save();
-        $this->assertEquals($translation1, $o->getTranslation('en_EN'));
+        $this->assertEquals($translation1, $o->getTranslation('en_US'));
         $this->assertEquals($translation2, $o->getTranslation('fr_FR'));
     }
 }

--- a/test/testsuite/generator/behavior/i18n/I18nBehaviorPeerBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/i18n/I18nBehaviorPeerBuilderModifierTest.php
@@ -39,7 +39,7 @@ class I18nBehaviorPeerBuilderModifierTest extends PHPUnit_Framework_TestCase
 </database>
 EOF;
         PropelQuickBuilder::buildSchema($schema);
-        $this->assertEquals('en_EN', I18nBehaviorTest01Peer::DEFAULT_LOCALE);
+        $this->assertEquals('en_US', I18nBehaviorTest01Peer::DEFAULT_LOCALE);
         $this->assertEquals('fr_FR', I18nBehaviorTest02Peer::DEFAULT_LOCALE);
     }
 

--- a/test/testsuite/generator/behavior/i18n/I18nBehaviorQueryBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/i18n/I18nBehaviorQueryBuilderModifierTest.php
@@ -63,7 +63,7 @@ EOF;
         $sql = BasePeer::createSelectSQL($q, $params);
         $expectedSQL = 'SELECT  FROM i18n_behavior_test_11 LEFT JOIN i18n_behavior_test_11_i18n ON (i18n_behavior_test_11.ID=i18n_behavior_test_11_i18n.ID AND i18n_behavior_test_11_i18n.LOCALE = :p1)';
         $this->assertEquals($expectedSQL, $sql);
-        $this->assertEquals('en_EN', $params[0]['value']);
+        $this->assertEquals('en_US', $params[0]['value']);
     }
 
     public function testJoinI18nUsesLocaleInJoinCondition()
@@ -80,23 +80,23 @@ EOF;
     public function testJoinI18nAcceptsARelationAlias()
     {
         $q = I18nBehaviorTest11Query::create()
-            ->joinI18n('en_EN', 'I18n');
+            ->joinI18n('en_US', 'I18n');
         $params = array();
         $sql = BasePeer::createSelectSQL($q, $params);
         $expectedSQL = 'SELECT  FROM i18n_behavior_test_11 LEFT JOIN i18n_behavior_test_11_i18n I18n ON (i18n_behavior_test_11.ID=I18n.ID AND I18n.LOCALE = :p1)';
         $this->assertEquals($expectedSQL, $sql);
-        $this->assertEquals('en_EN', $params[0]['value']);
+        $this->assertEquals('en_US', $params[0]['value']);
     }
 
     public function testJoinI18nAcceptsAJoinType()
     {
         $q = I18nBehaviorTest11Query::create()
-            ->joinI18n('en_EN', null, Criteria::INNER_JOIN);
+            ->joinI18n('en_US', null, Criteria::INNER_JOIN);
         $params = array();
         $sql = BasePeer::createSelectSQL($q, $params);
         $expectedSQL = 'SELECT  FROM i18n_behavior_test_11 INNER JOIN i18n_behavior_test_11_i18n ON (i18n_behavior_test_11.ID=i18n_behavior_test_11_i18n.ID AND i18n_behavior_test_11_i18n.LOCALE = :p1)';
         $this->assertEquals($expectedSQL, $sql);
-        $this->assertEquals('en_EN', $params[0]['value']);
+        $this->assertEquals('en_US', $params[0]['value']);
     }
 
     public function testJoinI18nCreatesACorrectQuery()
@@ -161,7 +161,7 @@ EOF;
         $sql = BasePeer::createSelectSQL($q, $params);
         $expectedSQL = 'SELECT i18n_behavior_test_11.ID, i18n_behavior_test_11.FOO, i18n_behavior_test_11_i18n.ID, i18n_behavior_test_11_i18n.LOCALE, i18n_behavior_test_11_i18n.BAR FROM i18n_behavior_test_11 LEFT JOIN i18n_behavior_test_11_i18n ON (i18n_behavior_test_11.ID=i18n_behavior_test_11_i18n.ID AND i18n_behavior_test_11_i18n.LOCALE = :p1)';
         $this->assertEquals($expectedSQL, $sql);
-        $this->assertEquals('en_EN', $params[0]['value']);
+        $this->assertEquals('en_US', $params[0]['value']);
     }
 
     public function testJoinWithI18nDoesNotPruneResultsWithoutTranslation()
@@ -172,7 +172,7 @@ EOF;
         $o->setFoo(123);
         $o->save();
         $res = I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN')
+            ->joinWithI18n('en_US')
             ->findOne();
         $this->assertEquals($o, $res);
     }
@@ -185,7 +185,7 @@ EOF;
         $o->setFoo(123);
         $o->save();
         $res = I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN', Criteria::INNER_JOIN)
+            ->joinWithI18n('en_US', Criteria::INNER_JOIN)
             ->findOne();
         $this->assertNull($res);
     }
@@ -198,7 +198,7 @@ EOF;
         I18nBehaviorTest11I18nQuery::create()->deleteAll();
         $o = new I18nBehaviorTest11();
         $o->setFoo(123);
-        $o->setLocale('en_EN');
+        $o->setLocale('en_US');
         $o->setBar('hello');
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
@@ -206,10 +206,10 @@ EOF;
         I18nBehaviorTest11Peer::clearInstancePool();
         I18nBehaviorTest11I18nPeer::clearInstancePool();
         $o = I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN')
+            ->joinWithI18n('en_US')
             ->findOne($con);
         $count = $con->getQueryCount();
-        $translation = $o->getTranslation('en_EN', $con);
+        $translation = $o->getTranslation('en_US', $con);
         $this->assertEquals($count, $con->getQueryCount());
         $this->assertEquals('hello', $translation->getBar());
     }
@@ -220,15 +220,15 @@ EOF;
         I18nBehaviorTest11I18nQuery::create()->deleteAll();
         $o = new I18nBehaviorTest11();
         $o->setFoo(123);
-        $o->setLocale('en_EN');
+        $o->setLocale('en_US');
         $o->setBar('hello');
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
         $o->save();
         $o1 = I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN')
+            ->joinWithI18n('en_US')
             ->findOne();
-        $this->assertEquals('en_EN', $o1->getLocale());
+        $this->assertEquals('en_US', $o1->getLocale());
         $o2 = I18nBehaviorTest11Query::create()
             ->joinWithI18n('fr_FR')
             ->findOne();
@@ -238,7 +238,7 @@ EOF;
     public function testJoinWithI18nAndLimitDoesNotThrowException()
     {
         $res = I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN')
+            ->joinWithI18n('en_US')
             ->limit(2)
             ->find();
         $this->assertInstanceOf('PropelObjectCollection', $res);
@@ -250,7 +250,7 @@ EOF;
     // use case:
     // $o = new Object();
     // $t1 = new Translation();
-    // $o->setTranslation($t2, 'en_EN'); // this is what happens during joined hydration
+    // $o->setTranslation($t2, 'en_US'); // this is what happens during joined hydration
     // now the translation collection exists
     // $t2 = $o->getTranslation('fr_FR'); // we MUST issue a query here
     public function testJoinWithI18nDoesNotExecuteAdditionalQueryWhenNoTranslationIsFound()
@@ -263,10 +263,10 @@ EOF;
         $o = new I18nBehaviorTest11();
         $o->save();
         $o = I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN')
+            ->joinWithI18n('en_US')
             ->findOne($con);
         $count = $con->getQueryCount();
-        $translation = $o->getTranslation('en_EN', $con);
+        $translation = $o->getTranslation('en_US', $con);
         $this->assertEquals($count, $con->getQueryCount());
     }
 

--- a/test/testsuite/generator/behavior/i18n/I18nBehaviorTest.php
+++ b/test/testsuite/generator/behavior/i18n/I18nBehaviorTest.php
@@ -111,7 +111,7 @@ EOF;
     </table>
     <table name="i18n_behavior_test_0_i18n">
         <column name="id" primaryKey="true" type="INTEGER" />
-        <column name="locale" primaryKey="true" type="VARCHAR" size="5" default="en_EN" />
+        <column name="locale" primaryKey="true" type="VARCHAR" size="5" default="en_US" />
         <column name="bar" type="VARCHAR" size="100" />
         <foreign-key foreignTable="i18n_behavior_test_0">
             <reference local="id" foreign="id" />
@@ -166,7 +166,7 @@ EOF;
 CREATE TABLE i18n_behavior_test_0_i18n
 (
     id INTEGER NOT NULL,
-    locale VARCHAR(5) DEFAULT 'en_EN' NOT NULL,
+    locale VARCHAR(5) DEFAULT 'en_US' NOT NULL,
 EOF;
         $this->assertContains($expected, $builder->getSQL());
     }
@@ -182,7 +182,7 @@ EOF;
 CREATE TABLE i18n_behavior_test_0_i18n
 (
     id INTEGER NOT NULL,
-    locale VARCHAR(5) DEFAULT 'en_EN' NOT NULL,
+    locale VARCHAR(5) DEFAULT 'en_US' NOT NULL,
     bar VARCHAR(100),
     PRIMARY KEY (id,locale)
 );
@@ -281,7 +281,7 @@ DROP TABLE IF EXISTS foo_table;
 CREATE TABLE foo_table
 (
     id INTEGER NOT NULL,
-    locale VARCHAR(5) DEFAULT 'en_EN' NOT NULL,
+    locale VARCHAR(5) DEFAULT 'en_US' NOT NULL,
     PRIMARY KEY (id,locale)
 );
 EOF;
@@ -312,7 +312,7 @@ DROP TABLE IF EXISTS i18n_behavior_test_0_i18n;
 CREATE TABLE i18n_behavior_test_0_i18n
 (
     id INTEGER NOT NULL,
-    culture VARCHAR(5) DEFAULT 'en_EN' NOT NULL,
+    culture VARCHAR(5) DEFAULT 'en_US' NOT NULL,
     PRIMARY KEY (id,culture)
 );
 EOF;


### PR DESCRIPTION
filterByPrimaryKey needed to be able to be called for a composite primary key which exists as an array versus a string for a regular primary key.

I have no idea what else may be missing in terms of suport for saving.

This seems to work for fetching.

Looking for guidance.
