### PR TITLE
Fix for one-to-one related object have unnecessary queries during hydration

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -3254,7 +3254,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
      * @return $className The associated $className object.
      * @throws PropelException
      */
-    public function get".$this->getFKPhpNameAffix($fk, $plural = false)."(PropelPDO \$con = null, \$doQuery)
+    public function get".$this->getFKPhpNameAffix($fk, $plural = false)."(PropelPDO \$con = null, \$doQuery = true)
     {";
         $script .= "
         if (\$this->$varName === null && ($conditional) && \$doQuery) {";


### PR DESCRIPTION
This is to resolve https://github.com/propelorm/Propel/issues/476
