### PR TITLE
Fixed problem about datetime on primary keys

### DIFF
--- a/generator/lib/builder/om/PHP5PeerBuilder.php
+++ b/generator/lib/builder/om/PHP5PeerBuilder.php
@@ -806,11 +806,11 @@ abstract class ".$this->getClassname(). $extendingPeerClass . "
             $script .= "serialize(array(";
             $i = 0;
             foreach ($pkphp as $pkvar) {
-                $script .= ($i++ ? ', ' : '') . "(string) $pkvar";
+                $script .= ($i++ ? ', ' : '') . $pkvar;
             }
             $script .= "))";
         } else {
-            $script .= "(string) " . $pkphp[0];
+            $script .= $pkphp[0];
         }
 
         return $script;


### PR DESCRIPTION
If you have a datetime type on a primary key, when you generate a key for pool you obtained:

ERROR: Catchable Fatal Error: Object of class DateTime could not be converted to string in ... line ...

It's occurs because it tries to convert pk to string before serialize. 

The generated code tries to do something like this (example):

serialize(array( (string) $obj->getDate()));

But php DateTime object can't cast to string. I have changed the code generator to avoid doing casting. This way it works for every data type on primary keys. The new generated code is something like this (fixed example):

serialize(array( $obj->getDate()));
