### PR TITLE
Fix issue #480 with concrete_inheritance and namespace

### DIFF
--- a/generator/lib/behavior/concrete_inheritance/ConcreteInheritanceBehavior.php
+++ b/generator/lib/behavior/concrete_inheritance/ConcreteInheritanceBehavior.php
@@ -207,7 +207,7 @@ public function getParentOrCreate(\$con = null)
             if (null === (\$parent = \$this->get". $parentClass . "(\$con))) {
                 \$parent = new " . $parentClass . "();
             }
-            \$parent->set" . $this->getParentTable()->getColumn($this->getParameter('descendant_column'))->getPhpName() . "('" . $this->builder->getStubObjectBuilder()->getClassname() . "');
+            \$parent->set" . $this->getParentTable()->getColumn($this->getParameter('descendant_column'))->getPhpName() . "('" . $this->builder->getStubObjectBuilder()->getFullyQualifiedClassname() . "');
 
             return \$parent;
         } else {

--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -253,7 +253,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
         $this->declareClassFromBuilder($this->getStubPeerBuilder());
         $this->declareClassFromBuilder($this->getStubQueryBuilder());
         $this->declareClasses(
-            'Propel', 'PropelException', 'PDO', 'PropelPDO', 'Criteria',
+            'Propel', 'PropelException', 'PDO', 'PropelPDO', 'PropelQuery', 'Criteria',
             'Persistent', 'BasePeer', 'PropelCollection',
             'PropelObjectCollection', 'Exception'
         );


### PR DESCRIPTION
Fix issue described:
- https://github.com/propelorm/PropelBundle/issues/162 (wrong repository)
- https://github.com/propelorm/Propel/issues/480

I did not find how to launch unit tests? When I try to execute them, I got a "bookstore-conf.php file is missing" error. 
