### PR TITLE
Fix findOneOrCreate with single inheritance and namespace

### DIFF
--- a/generator/lib/builder/om/QueryInheritanceBuilder.php
+++ b/generator/lib/builder/om/QueryInheritanceBuilder.php
@@ -163,7 +163,7 @@ class "  .$this->getClassname() . " extends " . $baseClassname . " {
     protected function addClassBody(&$script)
     {
         $this->declareClassFromBuilder($this->getStubPeerBuilder());
-        $this->declareClasses('PropelPDO', 'Criteria');
+        $this->declareClasses('PropelPDO', 'Criteria', 'BasePeer');
         $this->addFactory($script);
         $this->addPreSelect($script);
         $this->addPreUpdate($script);

--- a/test/testsuite/generator/builder/NamespaceTest.php
+++ b/test/testsuite/generator/builder/NamespaceTest.php
@@ -260,4 +260,11 @@ class NamespaceTest extends PHPUnit_Framework_TestCase
         $this->assertNull($book);
     }
 
+    public function testFindOneOrCreateFunction()
+    {
+        \Foo\Bar\NamespacedBookstoreCashierQuery::create()->deleteAll();
+
+        $cashier = \Foo\Bar\NamespacedBookstoreCashierQuery::create()->findOneOrCreate();
+        $this->assertTrue($cashier instanceof \Foo\Bar\NamespacedBookstoreCashier, 'findOneOrCreate return right object when create one : NamespacedBookstoreCashier');
+    }
 }


### PR DESCRIPTION
Fix bug see by kcivey.

BasePeer is not in the use liste when generate with namespace
