### PR TITLE
Fix strict standards error in Archivable & Concrete Inheritance

### DIFF
--- a/generator/lib/behavior/archivable/templates/objectPopulateFromArchive.php
+++ b/generator/lib/behavior/archivable/templates/objectPopulateFromArchive.php
@@ -3,16 +3,18 @@
  * Populates the the current object based on a $archiveTablePhpName archive object.
  *
  * @param      <?php echo $archiveTablePhpName ?> $archive An archived object based on the same class
- <?php if ($usesAutoIncrement): ?>
+ <?php if ($usesAutoIncrement && !$fakeAutoIncrementParameter): ?>
  * @param      Boolean $populateAutoIncrementPrimaryKeys
  *               If true, autoincrement columns are copied from the archive object.
  *               If false, autoincrement columns are left intact.
+ <?php elseif ($fakeAutoIncrementParameter): ?>
+ * @param      Boolean $populateAutoIncrementPrimaryKeys Not used! Defined to comply with php strict standards
  <?php endif; ?>
  *
  * @return     <?php echo $objectClassname ?> The current object (for fluent API support)
  */
-public function populateFromArchive($archive<?php if ($usesAutoIncrement): ?>, $populateAutoIncrementPrimaryKeys = false<?php endif; ?>) {
-<?php if ($usesAutoIncrement): ?>
+public function populateFromArchive($archive<?php if ($usesAutoIncrement || $fakeAutoIncrementParameter): ?>, $populateAutoIncrementPrimaryKeys = false<?php endif; ?>) {
+<?php if ($usesAutoIncrement && !$fakeAutoIncrementParameter): ?>
     if ($populateAutoIncrementPrimaryKeys) {
 <?php foreach ($columns as $col): ?>
 <?php if ($col->isAutoIncrement()): ?>


### PR DESCRIPTION
When archivable behavior is used in conjunction with concrete inheritance
on both concrete inheritance tables, the child table's populateFromArchive()
method needs to keep the same interface as the parent's
