### PR TITLE
Fix: PHP5TableMapBuilder and behaviors

### DIFF
--- a/generator/lib/builder/om/PHP5TableMapBuilder.php
+++ b/generator/lib/builder/om/PHP5TableMapBuilder.php
@@ -332,11 +332,7 @@ class ".$this->getClassname()." extends TableMap
         return array(";
             foreach ($behaviors as $behavior) {
                 $script .= "
-            '{$behavior->getName()}' => array(";
-                foreach ($behavior->getParameters() as $key => $value) {
-                    $script .= "'$key' => '$value', ";
-                }
-                $script .= "),";
+            '{$behavior->getName()}' =>  ". var_export($behavior->getParameters(), true) . ",";
             }
             $script .= "
         );


### PR DESCRIPTION
Behaviors parameters were not dumped correctly: try dumping non scalar values (like arrays) to see the error.
This can be a problem when a behaviors uses arrays as parameters.
