### PR TITLE
fix problem when deleting a reference when FK is part of foreign PK

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -3822,7 +3822,6 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
     {
         \${$inputCollection}ToDelete = \$this->get{$relatedName}(new Criteria(), \$con)->diff(\${$inputCollection});
 
-
         \$this->{$inputCollection}ScheduledForDeletion = unserialize(serialize(\${$inputCollection}ToDelete));
 
         foreach (\${$inputCollection}ToDelete as \${$inputCollectionEntry}Removed) {

--- a/test/testsuite/generator/builder/om/GeneratedObjectTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectTest.php
@@ -681,7 +681,6 @@ class GeneratedObjectTest extends BookstoreTestBase
         $this->assertEquals($op->getBookId(), $opinions[0]->getBookId());
     }
 
-
     /**
      * Test removing object when FK is part of the composite PK
      */


### PR DESCRIPTION
Here is a example to better explain the problem and the solution.

2 tables: request & requestStockCode

request:
id   -> PK
name

requestStockCode
request_id -> PK
stockCode -> PK
comment

when deleting a stockcode from the request object, the request_id colulmn in the requestStockCode object was set to null, even in the "deletion" list. When the doSave() function was called, no entry in the requestStockCode table was deleted because the request_id was null on each of these object.

The "clone" keyword was missing so that the "deletion" list of objects would be unaffected by setting the FK to null.
