### PR TITLE
fix variable name on boolean filter methods

### DIFF
--- a/generator/lib/builder/om/QueryBuilder.php
+++ b/generator/lib/builder/om/QueryBuilder.php
@@ -932,7 +932,7 @@ abstract class ".$this->getClassname()." extends " . $parentClass . "
         } elseif ($col->isBooleanType()) {
             $script .= "
         if (is_string(\$$variableName)) {
-            \$$colName = in_array(strtolower(\$$variableName), array('false', 'off', '-', 'no', 'n', '0', '')) ? false : true;
+            \$$variableName = in_array(strtolower(\$$variableName), array('false', 'off', '-', 'no', 'n', '0', '')) ? false : true;
         }";
         }
         $script .= "


### PR DESCRIPTION
Fixes `filterBy` methods of boolean columns, with expanded names.

``` patch
diff --git a/src/Ormigo/Model/User/om/BaseUserQuery.php b/src/Ormigo/Model/User/om/BaseUserQuery.php
index b8b2ad2..db4141d 100644
--- a/src/Ormigo/Model/User/om/BaseUserQuery.php
+++ b/src/Ormigo/Model/User/om/BaseUserQuery.php
@@ -840,7 +840,7 @@ abstract class BaseUserQuery extends ModelCriteria
     public function filterByCredentialsExpired($credentialsExpired = null, $comparison = null)
     {
         if (is_string($credentialsExpired)) {
-            $credentials_expired = in_array(strtolower($credentialsExpired), array('false', 'off', '-', 'no', 'n', '0', '')) ? false : true;
+            $credentialsExpired = in_array(strtolower($credentialsExpired), array('false', 'off', '-', 'no', 'n', '0', '')) ? false : true;
         }

         return $this->addUsingAlias(UserPeer::CREDENTIALS_EXPIRED, $credentialsExpired, $comparison);
```
