### PR TITLE
fixed with property naming in criteria

### DIFF
--- a/generator/lib/behavior/i18n/templates/queryJoinWithI18n.php
+++ b/generator/lib/behavior/i18n/templates/queryJoinWithI18n.php
@@ -13,7 +13,7 @@ public function joinWithI18n($locale = '<?php echo $defaultLocale ?>', $joinType
     $this
         ->joinI18n($locale, null, $joinType)
         ->with('<?php echo $i18nRelationName ?>');
-    $this->with['<?php echo $i18nRelationName ?>']->setIsWithOneToMany(false);
+    $this->modelWith['<?php echo $i18nRelationName ?>']->setIsWithOneToMany(false);
 
     return $this;
 }

--- a/generator/lib/builder/om/QueryBuilder.php
+++ b/generator/lib/builder/om/QueryBuilder.php
@@ -437,7 +437,7 @@ abstract class ".$this->getClassname()." extends " . $parentClass . "
             \$con = Propel::getConnection({$peerClassname}::DATABASE_NAME, Propel::CONNECTION_READ);
         }
         \$this->basePreSelect(\$con);
-        if (\$this->formatter || \$this->modelAlias || \$this->with || \$this->select
+        if (\$this->formatter || \$this->modelAlias || \$this->modelWith || \$this->select
          || \$this->selectColumns || \$this->asColumns || \$this->selectModifiers
          || \$this->map || \$this->having || \$this->joins) {
             return \$this->findPkComplex(\$key, \$con);

--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -46,7 +46,7 @@ class ModelCriteria extends Criteria
     protected $primaryCriteria;
     protected $formatter;
     protected $defaultFormatterClass = ModelCriteria::FORMAT_OBJECT;
-    protected $with = array();
+    protected $modelWith = array();
     protected $isWithOneToMany = false;
     protected $previousJoin = null; // this is introduced to prevent useQuery->join from going wrong
     protected $isKeepQuery = true; // whether to clone the current object before termination methods
@@ -835,7 +835,7 @@ class ModelCriteria extends Criteria
         $this->addRelationSelectColumns($relation);
 
         // list the join for later hydration in the formatter
-        $this->with[$relation] = new ModelWith($join);
+        $this->modelWith[$relation] = new ModelWith($join);
 
         return $this;
     }
@@ -849,7 +849,7 @@ class ModelCriteria extends Criteria
      */
     public function getWith()
     {
-        return $this->with;
+        return $this->modelWith;
     }
 
     /**
@@ -862,7 +862,7 @@ class ModelCriteria extends Criteria
      */
     public function setWith($with)
     {
-        $this->with = $with;
+        $this->modelWith = $with;
 
         return $this;
     }
@@ -965,7 +965,7 @@ class ModelCriteria extends Criteria
 
         // merge with
         if ($criteria instanceof ModelCriteria) {
-            $this->with = array_merge($this->getWith(), $criteria->getWith());
+            $this->modelWith = array_merge($this->getWith(), $criteria->getWith());
         }
 
         return $this;
@@ -981,7 +981,7 @@ class ModelCriteria extends Criteria
     {
         parent::clear();
 
-        $this->with = array();
+        $this->modelWith = array();
         $this->primaryCriteria = null;
         $this->formatter=null;
 
@@ -2214,8 +2214,8 @@ class ModelCriteria extends Criteria
     public function __clone()
     {
         parent::__clone();
-        foreach ($this->with as $key => $join) {
-            $this->with[$key] = clone $join;
+        foreach ($this->modelWith as $key => $join) {
+            $this->modelWith[$key] = clone $join;
         }
         if (null !== $this->formatter) {
             $this->formatter = clone $this->formatter;


### PR DESCRIPTION
This is generally a bad idea to name class properties with the same name as their methods. This for example happens for `ModelCriteria` which has a method `with()` and a property `$with`.

This can be troublesome when using for example `call_user_func_array` which is used extensively in PHPSpec. For example look at this code: 

``` php
call_user_func_array($this->$method, $arguments);
```

so the method `with()` does not even get called because an access violation to protected property. I know it can be done like this:

``` php
call_user_func_array(array($this, $method), $arguments);
```

But this is what currently PHPSpec does because it is a Mock object that holds mocked methods under property names. I'm not saying this is not a PHPSpec issue as well but nevertheless the property name could be changed to avoid situations like that.
