### PR TITLE
Removed the `extend <BasePeer>` in PHP5PeerBuilder since it's a bug.

### DIFF
--- a/generator/lib/builder/om/PHP5PeerBuilder.php
+++ b/generator/lib/builder/om/PHP5PeerBuilder.php
@@ -123,8 +123,6 @@ class PHP5PeerBuilder extends PeerBuilder
         $parentClass = $this->getBehaviorContent('parentClass');
         if (null !== $parentClass) {
             $extendingPeerClass = ' extends ' . $parentClass;
-        } elseif ($this->basePeerClassname !== 'BasePeer') {
-            $extendingPeerClass = ' extends ' . $this->basePeerClassname;
         }
 
         $script .= "


### PR DESCRIPTION
As mentioned and explained in #572, the `extend <BasePeer>` is a bug.
