### PR TITLE
In the Task `PorpelSQLDiffTask` the `disableIdentifierQuoting` build property was not handled

### DIFF
--- a/generator/lib/config/GeneratorConfig.php
+++ b/generator/lib/config/GeneratorConfig.php
@@ -170,6 +170,11 @@ class GeneratorConfig implements GeneratorConfigInterface
             throw new BuildException("Specified platform class ($clazz) does not implement teh PropelPlatformInterface interface.");
         }
 
+        if ($this->getBuildProperty('disableIdentifierQuoting')) {
+            $platform->setIdentifierQuoting(false);
+        } else {
+            $platform->setIdentifierQuoting(true);
+        }
         $platform->setConnection($con);
         $platform->setGeneratorConfig($this);
 


### PR DESCRIPTION
Before this PR, the task 'sql-diff' did always include quotes around identifier, no matter if you set `disableIdentifierQuoting` to `true` or not.
