### PR TITLE
break on first validation error,...

### DIFF
--- a/runtime/lib/util/BasePeer.php
+++ b/runtime/lib/util/BasePeer.php
@@ -572,8 +572,10 @@ class BasePeer
                 foreach ($col->getValidators() as $validatorMap) {
                     $validator = BasePeer::getValidator($validatorMap->getClass());
                     if ($validator && ($col->isNotNull() || $colValue !== null) && $validator->isValid($validatorMap, $colValue) === false) {
-                        if (!isset($failureMap[$colName])) { // for now we do one ValidationFailed per column, not per rule
+                        // for now we do one ValidationFailed per column, not per rule
+                        if (!isset($failureMap[$colName])) {
                             $failureMap[$colName] = new ValidationFailed($colName, $validatorMap->getMessage(), $validator);
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
because any further validation won't affect the result anyway. saves a few cpu-cycles.
