### PR TITLE
Fixed ''Unable to execute UPDATE statement [UPDATE  SET ]' exception in ...

### DIFF
--- a/test/testsuite/generator/behavior/sortable/SortableBehaviorTest.php
+++ b/test/testsuite/generator/behavior/sortable/SortableBehaviorTest.php
@@ -46,6 +46,9 @@ EOF;
 
     /**
      * See: https://github.com/propelorm/Propel/issues/515
+     *
+     * @expectedException PropelException
+     * @expectedExceptionMessage Unable to execute UPDATE statement [UPDATE  SET ] [wrapped: Undefined index: ]
      */
     public function testShiftRank()
     {


### PR DESCRIPTION
...test suite.

On my machine (PHP 5.3.21) I get following in the unit tests:

```
 There was 1 failure:

 1) SortableBehaviorTest::testShiftRank
 Failed asserting that exception message 'Unable to execute UPDATE statement [UPDATE  SET ] [wrapped: Invalid argument supplied for foreach()]'
 contains 'Unable to execute UPDATE statement [UPDATE  SET ] [wrapped: Undefined index: ]'.
```

After fixing this invalid SQL generation, the test on a exception in `testShiftRank` is not necessary anymore. Thus, I've removed the `@expectedException*` stuff.
