### PR TITLE
Fixed #601.

### DIFF
--- a/runtime/lib/util/BasePeer.php
+++ b/runtime/lib/util/BasePeer.php
@@ -334,8 +334,8 @@ class BasePeer
 
         // Get list of required tables, containing all columns
         $tablesColumns = $selectCriteria->getTablesColumns();
-        if (empty($tablesColumns)) {
-            $tablesColumns = array($selectCriteria->getPrimaryTableName() => array());
+        if (empty($tablesColumns) && ($table = $selectCriteria->getPrimaryTableName())) {
+            $tablesColumns = array($table => array());
         }
 
         // we also need the columns for the update SQL

--- a/test/testsuite/generator/behavior/sortable/SortableBehaviorTest.php
+++ b/test/testsuite/generator/behavior/sortable/SortableBehaviorTest.php
@@ -47,13 +47,11 @@ EOF;
     /**
      * See: https://github.com/propelorm/Propel/issues/515
      *
-     * @expectedException PropelException
-     * @expectedExceptionMessage Unable to execute UPDATE statement [UPDATE  SET ] [wrapped: Undefined index: ]
      */
     public function testShiftRank()
     {
         $peer = new \Test\SortableTest1Peer();
-        $peer->shiftRank(1);
+        $peer->shiftRank(1); //should not throw any exception
     }
 
     public function testParameters()

--- a/test/testsuite/generator/reverse/pgsql/PgsqlSchemaParserTest.php
+++ b/test/testsuite/generator/reverse/pgsql/PgsqlSchemaParserTest.php
@@ -48,7 +48,9 @@ class PgsqlSchemaParserTest extends PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
-        $this->con->rollback();
+        if ($this->con) {
+            $this->con->rollback();
+        }
 
         parent::tearDown();
         Propel::init(dirname(__FILE__) . '/../../../../fixtures/bookstore/build/conf/bookstore-conf.php');


### PR DESCRIPTION
The error_reporting level `E_ALL & ~E_NOTICE` in PHP generates some failures in the test suite.
This is the fix for that and for the `PgsqlSchemaParserTest` fatal error, both mentioned in #601.
