### PR TITLE
DatabaseMap::getTableByPhpName($phpName) with no namespaces

### DIFF
--- a/runtime/lib/map/DatabaseMap.php
+++ b/runtime/lib/map/DatabaseMap.php
@@ -168,7 +168,7 @@ class DatabaseMap
     {
         if (array_key_exists($phpName, $this->tablesByPhpName)) {
             return $this->tablesByPhpName[$phpName];
-        } elseif (class_exists($tmClass = substr_replace($phpName, '\\map\\', strrpos($phpName, '\\'), 1) . 'TableMap')) {
+        } elseif (class_exists($tmClass = substr_replace($phpName, '\\map\\', strrpos($phpName, '\\'), strrpos($phpName, '\\') === false ? 0 : 1) . 'TableMap')) {
             $this->addTableFromMapClass($tmClass);
 
             return $this->tablesByPhpName[$phpName];


### PR DESCRIPTION
Correctly add map namespace when **$phpName** has no backslash (e.g. namespaces are not used) to fix #614.

I did not write a unit test, but it should be focused checking **getTableByPhpName($phpName)** with **$phpName** being:
- _Foo_
- _FooBar_ 
- _myNameSpace\Foo_
- _myNameSpace\FooBar_
- _myNameSpace\FooBar\Baz_
