### PR TITLE
propel-gen.bat different when installing Propel via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,5 @@
       "url": "http://pear.php.net"
     }
   ],
-  "bin": ["generator/bin/propel-gen", "generator/bin/propel-gen.bat"]
+  "bin": ["generator/bin/propel-gen.bat", "generator/bin/propel-gen"]
 }


### PR DESCRIPTION
Just moved away from a PEAR setup propel project and went to a composer based approach.

After installing propel1 using composer I recognized, that the `propel-gen.bat` contains:

```
@ECHO OFF
SET BIN_TARGET=%~dp0\"../propel/propel1/generator/bin"\propel-gen
bash "%BIN_TARGET%" %*
```

when running `vendor\bin\propel-gen.bat` it aborts with a `bash not found` error.
