### PR TITLE
Fixes JOIN duplication issue when default join type equals given one (issue #373)

### DIFF
--- a/runtime/lib/query/Criteria.php
+++ b/runtime/lib/query/Criteria.php
@@ -963,7 +963,15 @@ class Criteria implements IteratorAggregate
      */
     public function addJoinObject(Join $join)
     {
-      if (!in_array($join, $this->joins)) { // compare equality, NOT identity
+        $isAlreadyAdded = false;
+        foreach ($this->joins as $alreadyAddedJoin) {
+            if ($join->equals($alreadyAddedJoin)) {
+                $isAlreadyAdded = true;
+                break;
+            }
+        }
+
+        if (!$isAlreadyAdded) {
             $this->joins[] = $join;
         }
 

--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -770,7 +770,15 @@ class ModelCriteria extends Criteria
      */
     public function addJoinObject(Join $join, $name = null)
     {
-        if (!in_array($join, $this->joins)) { // compare equality, NOT identity
+        $isAlreadyAdded = false;
+        foreach ($this->joins as $alreadyAddedJoin) {
+            if ($join->equals($alreadyAddedJoin)) {
+                $isAlreadyAdded = true;
+                break;
+            }
+        }
+
+        if (!$isAlreadyAdded) {
             if (null === $name) {
                 $this->joins[] = $join;
             } else {

--- a/test/testsuite/runtime/query/CriteriaTest.php
+++ b/test/testsuite/runtime/query/CriteriaTest.php
@@ -884,7 +884,7 @@ class CriteriaTest extends BookstoreTestBase
 
         $c->addJoin("tbl.COL1", "tbl.COL2", Criteria::LEFT_JOIN);
         $c->addJoin("tbl.COL1", "tbl.COL2", Criteria::LEFT_JOIN);
-        $this->assertEquals(1, count($c->getJoins()), "Expected not to have duplicate LJOIN added.");
+        $this->assertEquals(1, count($c->getJoins()), "Expected not to have duplicate LEFT JOIN added.");
 
         $c->addJoin("tbl.COL1", "tbl.COL2", Criteria::RIGHT_JOIN);
         $c->addJoin("tbl.COL1", "tbl.COL2", Criteria::RIGHT_JOIN);
@@ -893,6 +893,10 @@ class CriteriaTest extends BookstoreTestBase
         $c->addJoin("tbl.COL1", "tbl.COL2");
         $c->addJoin("tbl.COL1", "tbl.COL2");
         $this->assertEquals(3, count($c->getJoins()), "Expected 1 new implicit join to be added.");
+
+        $c->addJoin("tbl.COL1", "tbl.COL2", Criteria::INNER_JOIN);
+        $this->assertEquals(3, count($c->getJoins()), "Expected to not add any new join
+                                                        as INNER JOIN is default joinType and it is already added");
 
         $c->addJoin("tbl.COL3", "tbl.COL4");
         $this->assertEquals(4, count($c->getJoins()), "Expected new col join to be added.");

--- a/test/testsuite/runtime/query/ModelCriteriaTest.php
+++ b/test/testsuite/runtime/query/ModelCriteriaTest.php
@@ -905,6 +905,28 @@ class ModelCriteriaTest extends BookstoreTestBase
         $this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'join() allows the use of relation alias in further joins()');
     }
 
+    public function testJoinDuplicate()  {
+        $c = new ModelCriteria('bookstore', 'Author');
+        $c->addJoinObject(new Join('tbl.COL1', 'tbl.COL2', 'LEFT JOIN'));
+        $c->addJoinObject(new Join('tbl.COL1', 'tbl.COL2', 'LEFT JOIN'));
+        $this->assertEquals(1, count($c->getJoins()), 'Expected not to have duplicate LEFT JOIN added.');
+
+        $c->addJoinObject(new Join('tbl.COL1', 'tbl.COL2', 'RIGHT JOIN'));
+        $c->addJoinObject(new Join('tbl.COL1', 'tbl.COL2', 'RIGHT JOIN'));
+        $this->assertEquals(2, count($c->getJoins()), 'Expected 1 new right join to be added.');
+
+        $c->addJoinObject(new Join('tbl.COL1', 'tbl.COL2'));
+        $c->addJoinObject(new Join('tbl.COL1', 'tbl.COL2'));
+        $this->assertEquals(3, count($c->getJoins()), 'Expected 1 new implicit join to be added.');
+
+        $c->addJoinObject(new Join('tbl.COL1', 'tbl.COL2', 'INNER JOIN'));
+        $this->assertEquals(3, count($c->getJoins()), 'Expected to not add any new join
+                                                        as INNER JOIN is default joinType and it is already added');
+
+        $c->addJoinObject(new Join('tbl.COL3', 'tbl.COL4'));
+        $this->assertEquals(4, count($c->getJoins()), "Expected new col join to be added.");
+     }
+
     public function testAddJoinConditionSimple()
     {
         $con = Propel::getConnection(BookPeer::DATABASE_NAME);


### PR DESCRIPTION
This fixes issue #373.

Instead of checking object identity I switched to check if Joins equals.

I've provided fix for Criteria and ModelCriteria. For ModelCriteria I also added whole test set for checking if joins doesn't duplicate (similar to tests for Criteria).
