### PR TITLE
Added test: Update both directions in many-to-many relationship

### DIFF
--- a/test/testsuite/generator/builder/om/GeneratedObjectRelTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectRelTest.php
@@ -220,6 +220,9 @@ class GeneratedObjectRelTest extends BookstoreEmptyTestBase
         $this->assertEquals(1, $list->countBooks(), 'addCrossFk() sets the internal collection properly');
         $this->assertEquals(1, $list->countBookListRels(), 'addCrossFk() sets the internal cross reference collection properly');
 
+        $this->assertEquals(1, $book->countBookClubLists(), 'addCrossFk() sets the internal collection for related object properly');
+        $this->assertEquals(1, $book->countBookListRels(), 'addCrossFk() sets the internal cross reference collection for related object properly');
+
         $list->save();
         $this->assertFalse($book->isNew(), 'related object is saved if added');
         $rels = $list->getBookListRels();


### PR DESCRIPTION
As described in https://groups.google.com/forum/#!topic/propel-users/Ubc5A9awV3Q currently only one object of a many-to-many relation gets updated when adding (before saving).

Possible solution is mentioned by Marius Ghita in the link above.
