### PR TITLE
add locale length option for i18n behavior

### DIFF
--- a/generator/lib/behavior/i18n/I18nBehavior.php
+++ b/generator/lib/behavior/i18n/I18nBehavior.php
@@ -30,6 +30,7 @@ class I18nBehavior extends Behavior
         'i18n_columns'  => '',
         'i18n_pk_name'  => null,
         'locale_column' => 'locale',
+        'locale_length' => 5,
         'default_locale' => null,
         'locale_alias'  => '',
     );
@@ -128,7 +129,7 @@ class I18nBehavior extends Behavior
             $this->i18nTable->addColumn(array(
                 'name'       => $localeColumnName,
                 'type'       => PropelTypes::VARCHAR,
-                'size'       => 5,
+                'size'       => $this->getParameter('locale_length') ? (int) $this->getParameter('locale_length') : 5,
                 'default'    => $this->getDefaultLocale(),
                 'primaryKey' => 'true',
             ));

--- a/test/testsuite/generator/behavior/i18n/I18nBehaviorTest.php
+++ b/test/testsuite/generator/behavior/i18n/I18nBehaviorTest.php
@@ -401,7 +401,37 @@ EOF;
         $this->assertContains($expected, $builder->getSQL());
     }
 
+    public function testModiFyTableUsesCustomI18nLocaleLength()
+    {
+        $schema = <<<EOF
+<database name="i18n_behavior_test_0">
+    <table name="i18n_behavior_test_0">
+        <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
+        <behavior name="i18n">
+            <parameter name="locale_length" value="6" />
+        </behavior>
+    </table>
+</database>
+EOF;
+        $builder = new PropelQuickBuilder();
+        $builder->setSchema($schema);
+        $expected = <<<EOF
+-----------------------------------------------------------------------
+-- i18n_behavior_test_0_i18n
+-----------------------------------------------------------------------
 
+DROP TABLE IF EXISTS [i18n_behavior_test_0_i18n];
+
+CREATE TABLE [i18n_behavior_test_0_i18n]
+(
+    [id] INTEGER NOT NULL,
+    [locale] VARCHAR(6) DEFAULT 'en_US' NOT NULL,
+    PRIMARY KEY ([id],[locale])
+);
+EOF;
+        $this->assertContains($expected, $builder->getSQL());
+    }
+    
     public function testTableWithPrefix()
     {
         $schema = <<<EOF


### PR DESCRIPTION
Hi,

I think locale column length (5 chars) is too restrictive for some specific cases ( language code with 3 characters, different available alphabets for a same language or adding a transliteration identifier in the locale code) .

So  i added an option to easily change it.
