### PR TITLE
add lcfirst function stub

### DIFF
--- a/generator/lib/behavior/aggregate_column/AggregateColumnRelationBehavior.php
+++ b/generator/lib/behavior/aggregate_column/AggregateColumnRelationBehavior.php
@@ -56,7 +56,7 @@ class AggregateColumnRelationBehavior extends Behavior
 
         return $this->renderTemplate('objectUpdateRelated', array(
             'relationName'     => $relationName,
-            'variableName'     => self::lcfirst($relationName),
+            'variableName'     => lcfirst($relationName),
             'updateMethodName' => $this->getParameter('update_method'),
         ));
     }
@@ -128,7 +128,7 @@ class AggregateColumnRelationBehavior extends Behavior
         return $this->renderTemplate('queryFindRelated', array(
             'foreignTable'     => $this->getForeignTable(),
             'relationName'     => $relationName,
-            'variableName'     => self::lcfirst($relationName),
+            'variableName'     => lcfirst($relationName),
             'foreignQueryName' => $foreignQueryBuilder->getClassname(),
             'refRelationName'  => $builder->getRefFKPhpNameAffix($foreignKey),
         ));
@@ -140,7 +140,7 @@ class AggregateColumnRelationBehavior extends Behavior
 
         return $this->renderTemplate('queryUpdateRelated', array(
             'relationName'     => $relationName,
-            'variableName'     => self::lcfirst($relationName),
+            'variableName'     => lcfirst($relationName),
             'updateMethodName' => $this->getParameter('update_method'),
         ));
     }
@@ -163,13 +163,5 @@ class AggregateColumnRelationBehavior extends Behavior
     protected function getRelationName($builder)
     {
         return $builder->getFKPhpNameAffix($this->getForeignKey());
-    }
-
-    protected static function lcfirst($input)
-    {
-        // no lcfirst in php<5.3...
-        $input[0] = strtolower($input[0]);
-
-        return $input;
     }
 }

--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -4016,13 +4016,8 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         $relatedName = $this->getRefFKPhpNameAffix($refFK, $plural = true);
         $relatedObjectClassName = $this->getRefFKPhpNameAffix($refFK, $plural = false);
 
-        // No lcfirst() in PHP < 5.3
-        $inputCollection = $relatedName;
-        $inputCollection[0] = strtolower($inputCollection[0]);
-
-        // No lcfirst() in PHP < 5.3
-        $inputCollectionEntry = $this->getRefFKPhpNameAffix($refFK, $plural = false);
-        $inputCollectionEntry[0] = strtolower($inputCollectionEntry[0]);
+        $inputCollection = lcfirst($relatedName);
+        $inputCollectionEntry = lcfirst($this->getRefFKPhpNameAffix($refFK, $plural = false));
 
         $collName = $this->getRefFKCollVarName($refFK);
         $relCol = $this->getFKPhpNameAffix($refFK, $plural = false);
@@ -4084,9 +4079,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
     {
         $relatedObjectClassName = $this->getRefFKPhpNameAffix($refFK, $plural = false);
 
-        // lcfirst() doesn't exist in PHP < 5.3
-        $lowerRelatedObjectClassName = $relatedObjectClassName;
-        $lowerRelatedObjectClassName[0] = strtolower($lowerRelatedObjectClassName[0]);
+        $lowerRelatedObjectClassName = lcfirst($relatedObjectClassName);
 
         $collName = $this->getRefFKCollVarName($refFK);
 
@@ -4112,13 +4105,8 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         $relatedName = $this->getRefFKPhpNameAffix($refFK, $plural = true);
         $relatedObjectClassName = $this->getRefFKPhpNameAffix($refFK, $plural = false);
 
-        // No lcfirst() in PHP < 5.3
-        $inputCollection = $relatedName . 'ScheduledForDeletion';
-        $inputCollection[0] = strtolower($inputCollection[0]);
-
-        // lcfirst() doesn't exist in PHP < 5.3
-        $lowerRelatedObjectClassName = $relatedObjectClassName;
-        $lowerRelatedObjectClassName[0] = strtolower($lowerRelatedObjectClassName[0]);
+        $inputCollection = lcfirst($relatedName . 'ScheduledForDeletion');
+        $lowerRelatedObjectClassName = lcfirst($relatedObjectClassName);
 
         $collName = $this->getRefFKCollVarName($refFK);
         $relCol = $this->getFKPhpNameAffix($refFK, $plural = false);
@@ -4248,8 +4236,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
 
     protected function addScheduledForDeletionAttribute(&$script, $fkName)
     {
-        // No lcfirst() in PHP < 5.3
-        $fkName[0] = strtolower($fkName[0]);
+        $fkName = lcfirst($fkName);
 
         $script .= "
     /**
@@ -4264,12 +4251,9 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
     {
         $queryClassName = $this->getRefFKPhpNameAffix($refFK, $plural = false) . 'Query';
         $relatedName = $this->getFKPhpNameAffix($crossFK, $plural = true);
-        // No lcfirst() in PHP < 5.3
-        $lowerRelatedName = $relatedName;
-        $lowerRelatedName[0] = strtolower($lowerRelatedName[0]);
-        // No lcfirst() in PHP < 5.3
-        $lowerSingleRelatedName = $this->getFKPhpNameAffix($crossFK, $plural = false);
-        $lowerSingleRelatedName[0] = strtolower($lowerSingleRelatedName[0]);
+
+        $lowerRelatedName = lcfirst($relatedName);
+        $lowerSingleRelatedName = lcfirst($this->getFKPhpNameAffix($crossFK, $plural = false));
 
         $middelFks = $refFK->getTable()->getForeignKeys();
         $isFirstPk = ($middelFks[0]->getForeignTableCommonName() == $this->getTable()->getCommonName());
@@ -4314,12 +4298,8 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
     {
         $relatedName = $this->getRefFKPhpNameAffix($refFK, $plural = true);
 
-        // No lcfirst() in PHP < 5.3
-        $lowerRelatedName = $relatedName;
-        $lowerRelatedName[0] = strtolower($lowerRelatedName[0]);
-        // No lcfirst() in PHP < 5.3
-        $lowerSingleRelatedName = $this->getRefFKPhpNameAffix($refFK, $plural = false);
-        $lowerSingleRelatedName[0] = strtolower($lowerSingleRelatedName[0]);
+        $lowerRelatedName = lcfirst($relatedName);
+        $lowerSingleRelatedName = lcfirst($this->getRefFKPhpNameAffix($refFK, $plural = false));
 
         $queryClassName = $this->getNewStubQueryBuilder($refFK->getTable())->getClassname();
 
@@ -4483,13 +4463,8 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         $crossRefTableName = $crossFK->getTableName();
         $collName = $this->getCrossFKVarName($crossFK);
 
-        // No lcfirst() in PHP < 5.3
-        $inputCollection = $relatedNamePlural;
-        $inputCollection[0] = strtolower($inputCollection[0]);
-
-        // No lcfirst() in PHP < 5.3
-        $inputCollectionEntry = $this->getFKPhpNameAffix($crossFK, $plural = false);
-        $inputCollectionEntry[0] = strtolower($inputCollectionEntry[0]);
+        $inputCollection = lcfirst($relatedNamePlural);
+        $inputCollectionEntry = lcfirst($this->getFKPhpNameAffix($crossFK, $plural = false));
 
         $script .= "
     /**
@@ -4616,9 +4591,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
     {
         $relatedObjectClassName = $this->getFKPhpNameAffix($crossFK, $plural = false);
 
-        // lcfirst() doesn't exist in PHP < 5.3
-        $lowerRelatedObjectClassName = $relatedObjectClassName;
-        $lowerRelatedObjectClassName[0] = strtolower($lowerRelatedObjectClassName[0]);
+        $lowerRelatedObjectClassName = lcfirst($relatedObjectClassName);
 
         $joinedTableObjectBuilder = $this->getNewObjectBuilder($refFK->getTable());
         $className = $joinedTableObjectBuilder->getObjectClassname();

--- a/generator/lib/task/AbstractPropelDataModelTask.php
+++ b/generator/lib/task/AbstractPropelDataModelTask.php
@@ -9,7 +9,7 @@
  */
 
 //include_once 'phing/tasks/ext/CapsuleTask.php';
-require_once 'phing/Task.php';
+require_once 'task/AbstractPropelTask.php';
 include_once 'config/GeneratorConfig.php';
 include_once 'model/AppData.php';
 include_once 'model/Database.php';
@@ -26,7 +26,7 @@ include_once 'util/PropelSchemaValidator.php';
  * @author     Daniel Rall <dlr@finemaltcoding.com> (Torque)
  * @package    propel.generator.task
  */
-abstract class AbstractPropelDataModelTask extends Task
+abstract class AbstractPropelDataModelTask extends AbstractPropelTask
 {
 
     /**

--- a/generator/lib/task/AbstractPropelTask.php
+++ b/generator/lib/task/AbstractPropelTask.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+require_once 'phing/Task.php';
+require_once __DIR__ . '/../../stubs/functions.php';
+
+abstract class AbstractPropelTask extends Task
+{
+
+}

--- a/generator/lib/task/BasePropelMigrationTask.php
+++ b/generator/lib/task/BasePropelMigrationTask.php
@@ -8,7 +8,7 @@
  * @license    MIT License
  */
 
-require_once 'phing/Task.php';
+require_once 'task/AbstractPropelTask.php';
 
 /**
  * This Task lists the migrations yet to be executed
@@ -16,7 +16,7 @@ require_once 'phing/Task.php';
  * @author     Francois Zaninotto
  * @package    propel.generator.task
  */
-abstract class BasePropelMigrationTask extends Task
+abstract class BasePropelMigrationTask extends AbstractPropelTask
 {
     /**
      * Destination directory for results of template scripts.

--- a/generator/lib/task/PropelConvertConfTask.php
+++ b/generator/lib/task/PropelConvertConfTask.php
@@ -8,7 +8,7 @@
  * @license    MIT License
  */
 
-require_once 'phing/Task.php';
+require_once 'task/AbstractPropelTask.php';
 require_once 'task/AbstractPropelDataModelTask.php';
 require_once 'builder/om/OMBuilder.php';
 require_once 'builder/om/ClassTools.php';

--- a/generator/lib/task/PropelSQLExec.php
+++ b/generator/lib/task/PropelSQLExec.php
@@ -8,7 +8,7 @@
  * @license    MIT License
  */
 
-require_once 'phing/Task.php';
+require_once 'task/AbstractPropelTask.php';
 require_once dirname(__FILE__) . '/../util/PropelSQLParser.php';
 
 /**
@@ -27,7 +27,7 @@ require_once dirname(__FILE__) . '/../util/PropelSQLParser.php';
  * @version    $Revision$
  * @package    propel.generator.task
  */
-class PropelSQLExec extends Task
+class PropelSQLExec extends AbstractPropelTask
 {
 
     private $goodSql = 0;

--- a/generator/stubs/functions.php
+++ b/generator/stubs/functions.php
@@ -1,0 +1,9 @@
+<?php
+
+if (!function_exists('lcfirst')) {
+    function lcfirst($string) {
+        $string[0] = strtolower($string[0]);
+
+        return $string;
+    }
+}

--- a/runtime/lib/Propel.php
+++ b/runtime/lib/Propel.php
@@ -942,3 +942,7 @@ class Propel
 // Since the Propel class is not a true singleton, this code cannot go into the __construct()
 Propel::initBaseDir();
 spl_autoload_register(array('Propel', 'autoload'));
+
+if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+    require_once __DIR__ . '/../stubs/functions.php';
+}

--- a/runtime/lib/om/BaseObject.php
+++ b/runtime/lib/om/BaseObject.php
@@ -436,8 +436,8 @@ abstract class BaseObject
             if ($this->hasVirtualColumn($virtualColumn)) {
                 return $this->getVirtualColumn($virtualColumn);
             }
-            // no lcfirst in php<5.3...
-            $virtualColumn[0] = strtolower($virtualColumn[0]);
+
+            $virtualColumn = lcfirst($virtualColumn);
             if ($this->hasVirtualColumn($virtualColumn)) {
                 return $this->getVirtualColumn($virtualColumn);
             }

--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -2235,9 +2235,7 @@ class ModelCriteria extends Criteria
                     $arguments[0] = null;
                 }
                 array_push($arguments, $joinType);
-                $method = substr($name, $pos);
-                // no lcfirst in php<5.3...
-                $method[0] = strtolower($method[0]);
+                $method = lcfirst(substr($name, $pos));
 
                 return call_user_func_array(array($this, $method), $arguments);
             }

--- a/runtime/stubs/functions.php
+++ b/runtime/stubs/functions.php
@@ -1,0 +1,9 @@
+<?php
+
+if (!function_exists('lcfirst')) {
+    function lcfirst($string) {
+        $string[0] = strtolower($string[0]);
+
+        return $string;
+    }
+}


### PR DESCRIPTION
stubs directory is duplicated because `generator` and `runtime` may exist in different installation locations using PEAR.
