### PR TITLE
Fixed Bug #478

### DIFF
--- a/runtime/lib/om/BaseObject.php
+++ b/runtime/lib/om/BaseObject.php
@@ -292,7 +292,7 @@ abstract class BaseObject
             return crc32(serialize($this->getPrimaryKey()));
         }
 
-        return crc32(serialize(clone $this));
+        return crc32(serialize($this));
     }
 
     /**


### PR DESCRIPTION
Avoid clearing references on BaseObject in __sleep method
because this breaks setting foreign references. By cloning the
BaseObject itself we ensure the the Baseobject itself is not
changing but sleep still returning the same
