### PR TITLE
Bugfix for PHP < 5.3.0

### DIFF
--- a/runtime/lib/Propel.php
+++ b/runtime/lib/Propel.php
@@ -944,5 +944,5 @@ Propel::initBaseDir();
 spl_autoload_register(array('Propel', 'autoload'));
 
 if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-    require_once __DIR__ . '/../stubs/functions.php';
+    require_once dirname(__FILE__) . '/../stubs/functions.php';
 }


### PR DESCRIPTION
Constant `__DIR__` was added in PHP 5.3.0 ;)
