### PR TITLE
Fixed Sluggable behavior combining with symfony_i18n

### DIFF
--- a/generator/lib/behavior/sluggable/SluggableBehavior.php
+++ b/generator/lib/behavior/sluggable/SluggableBehavior.php
@@ -91,8 +91,12 @@ if (\$this->isColumnModified($const) && \$this->{$this->getColumnGetter()}()) {
             $count = preg_match_all('/{([a-zA-Z]+)}/', $pattern, $matches, PREG_PATTERN_ORDER);
 
             foreach ($matches[1] as $key => $match) {
-
-                $column = $this->getTable()->getColumn($this->underscore(ucfirst($match)));
+                $columnName = $this->underscore(ucfirst($match));
+                $column = $this->getTable()->getColumn($columnName);
+                if ((null == $column) && $this->getTable()->hasBehavior('symfony_i18n')) {
+                    $i18n = $this->getTable()->getBehavior('symfony_i18n');
+                    $column = $i18n->getI18nTable()->getColumn($columnName);
+                }
                 if (null == $column) {
                     throw new \InvalidArgumentException(sprintf('The pattern %s is invalid  the column %s is not found', $pattern, $match));
                 }


### PR DESCRIPTION
After commit https://github.com/propelorm/Propel/commit/ce4c8336d92f7ab372605279f3ea398200b3ab14 generating model for table with behaviors sluggable and symfony_i18n throws an exception when slug pattern contains fields from i18n-table:

```
[phingcall] The pattern {Title} is invalid  the column Title is not found
```

Schema:

``` yml
propel:
  news:
    _attributes:        { isI18N: true, i18nTable: news_i18n }
    id:                 ~
    created_at:         ~
    _propel_behaviors:
      sluggable:        { slug_pattern: '{Title}' }

  news_i18n:
    id:                 { type: integer, required: true, primaryKey: true, foreignTable: news, foreignReference: id, onDelete: cascade, onUpdate: cascade }
    culture:            { isCulture: true, type: varchar, sqlType: "enum('uk', 'ru', 'en')", default: 'uk', required: true, primaryKey: true }
    title:              { type: varchar, size: 255, primaryString: true }
```

The patch fixes this problem.

Also commit https://github.com/propelorm/Propel/commit/ce4c8336d92f7ab372605279f3ea398200b3ab14 broke ability to specify virtual columns in slug pattern, which have getters in the model or implicitly added by other behaviors, because of resolving columns at build-time, not runtime.
Maybe we should add special option to control this moment.
