### PR TITLE
fix column names in versionable with Postgres

### DIFF
--- a/generator/lib/behavior/versionable/VersionableBehavior.php
+++ b/generator/lib/behavior/versionable/VersionableBehavior.php
@@ -165,7 +165,7 @@ class VersionableBehavior extends Behavior
         }
 
         foreach ($this->getVersionableReferrers() as $fk) {
-            $fkTableName = $fk->getTable()->getName();
+            $fkTableName = $fk->getTable()->getCommonName();
 
             if ($fk->isLocalPrimaryKey()) {
                 $columns = array(
@@ -236,7 +236,7 @@ class VersionableBehavior extends Behavior
 
     public function getReferrerIdsColumn(ForeignKey $fk)
     {
-        $fkTableName = $fk->getTable()->getName();
+        $fkTableName = $fk->getTable()->getCommonName();
 
         if ($fk->isLocalPrimaryKey()) {
             $fkColumnName = $fkTableName . '_id';
@@ -249,7 +249,7 @@ class VersionableBehavior extends Behavior
 
     public function getReferrerVersionsColumn(ForeignKey $fk)
     {
-        $fkTableName = $fk->getTable()->getName();
+        $fkTableName = $fk->getTable()->getCommonName();
 
         if ($fk->isLocalPrimaryKey()) {
             $fkColumnName = $fkTableName . '_version';


### PR DESCRIPTION
When using Postgres, the versionable behavior produces invalid column names for the *_ids and *_versions columns, because the foreign table name it uses as a prefix includes the Postgres schema name and a dot. This pull request uses getCommonName() instead of getName() for the table name when generating the column names, thus leaving off the schema prefix.

This replaces the pull request submitted a while back as #498.
