### PR TITLE
Invalid arguments warning fix

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -1778,7 +1778,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         $script .= "
         if (\$this->$cloUnserialized !== \$v) {
             \$this->$cloUnserialized = \$v;
-            \$this->$clo = '| ' . implode(' | ', \$v) . ' |';
+            \$this->$clo = '| ' . implode(' | ', (array)\$v) . ' |';
             \$this->modifiedColumns[] = " . $this->getColumnConstant($col) . ";
         }
 ";


### PR DESCRIPTION
Obviously if we try to pass non-array value, it will result in Invalid arguments warning.
