### PR TITLE
Fix accidental type conversion in sluggable behavior.

### DIFF
--- a/generator/lib/behavior/sluggable/SluggableBehavior.php
+++ b/generator/lib/behavior/sluggable/SluggableBehavior.php
@@ -359,7 +359,7 @@ protected function makeSlugUnique(\$slug, \$separator = '" . $this->getParameter
     }
 
     \$slugNum = substr(\$object->" . $getter . "(), strlen(\$slug) + 1);
-    if (0 == \$slugNum[0]) {
+    if ('0' === \$slugNum[0]) {
         \$slugNum[0] = 1;
     }
 


### PR DESCRIPTION
This generated code:

```
$slugNum = substr($object->getAccountId(), strlen($slug) + 1);
if (0 == $slugNum[0]) {
    $slugNum[0] = 1;
}

return $slug2 . ($slugNum + 1);
```

will turn `$slugNum` into an array if substr returns false. By checking
with `===`, this is avoided.
