### PR TITLE
fix for datadump task to use datasource's credentials instead of build.properties

### DIFF
--- a/generator/lib/task/PropelDataDumpTask.php
+++ b/generator/lib/task/PropelDataDumpTask.php
@@ -281,19 +281,7 @@ class PropelDataDumpTask extends AbstractPropelDataModelTask
                     $this->log("Writing to XML file: " . $outFile->getName());
 
                     try {
-
-                        $url = str_replace("@DB@", $database->getName(), $this->databaseUrl);
-
-                        if ($url !== $this->databaseUrl) {
-                            $this->log("New (resolved) URL: " . $url, Project::MSG_VERBOSE);
-                        }
-
-                        if (empty($url)) {
-                            throw new BuildException("Unable to connect to database; no PDO connection URL specified.", $this->getLocation());
-                        }
-
-                        $this->conn = new PDO($url, $this->databaseUser, $this->databasePassword);
-                        $this->conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                        $this->conn = $dataModel->getGeneratorConfig()->getBuildPDO($database->getName());
 
                         $doc = $this->createXMLDoc($database);
                         $doc->save($outFile->getAbsolutePath());


### PR DESCRIPTION
...properties) while performing datadump task

when performing datasql and insert-sql taks propel uses connection from buildtime-conf.xml, but when you perform datadump task it ignores datasources connections and won't work until you define global connection in build.properties
