### PR TITLE
Objects's serialization in the XML export

### DIFF
--- a/runtime/lib/parser/PropelXMLParser.php
+++ b/runtime/lib/parser/PropelXMLParser.php
@@ -190,7 +190,11 @@ class PropelXMLParser extends PropelParser
             } elseif (!$element->hasChildNodes()) {
                 $array[$index] = null;
             } else {
-                $array[$index] = $element->textContent;
+                if (false !== ($unserialized_content = @unserialize($element->textContent))) {
+                    $array[$index] = $unserialized_content;
+                } else {
+                    $array[$index] = $element->textContent;
+                }
             }
         }
 


### PR DESCRIPTION
When a Propel object is exported to XML and contains an object (eg. DateTime), this error appear: "Warning: DOMDocument::createTextNode() expects parameter 1 to be string". This patch corrects the issue.
