### PR TITLE
fix problem with enum type in generating diff

### DIFF
--- a/generator/lib/model/diff/PropelColumnComparator.php
+++ b/generator/lib/model/diff/PropelColumnComparator.php
@@ -56,7 +56,13 @@ class PropelColumnComparator
         $fromDomain = $fromColumn->getDomain();
         $toDomain = $toColumn->getDomain();
         if ($fromDomain->getType() != $toDomain->getType()) {
-            $changedProperties['type'] = array($fromDomain->getType(), $toDomain->getType());
+            if ($toDomain->getType() == 'ENUM') {
+                if ($toDomain->getSqlType() != $fromDomain->getType() ) {
+                    $changedProperties['type'] = array($fromDomain->getType(), $toDomain->getType());
+                }
+            } else {
+                $changedProperties['type'] = array($fromDomain->getType(), $toDomain->getType());
+            }
         }
         if ($fromDomain->getScale() != $toDomain->getScale()) {
             $changedProperties['scale'] = array($fromDomain->getScale(), $toDomain->getScale());
@@ -86,7 +92,15 @@ class PropelColumnComparator
                     $changedProperties['defaultValueType'] = array($fromDefaultValue->getType(), $toDefaultValue->getType());
                 }
                 if ($fromDefaultValue->getValue() != $toDefaultValue->getValue()) {
-                    $changedProperties['defaultValueValue'] = array($fromDefaultValue->getValue(), $toDefaultValue->getValue());
+                    if ($toDomain->getType() == 'ENUM') {
+                        $values = $toColumn->getValueSet();
+                        if (!isset($values[$fromDefaultValue->getValue()]) ||
+                            $values[$fromDefaultValue->getValue()] != $toDefaultValue->getValue()) {
+                            $changedProperties['defaultValueValue'] = array($fromDefaultValue->getValue(), $toDefaultValue->getValue());
+                        }
+                    } else {
+                        $changedProperties['defaultValueValue'] = array($fromDefaultValue->getValue(), $toDefaultValue->getValue());
+                    }
                 }
             }
         }


### PR DESCRIPTION
I have a table like this :  

```
<table name="test" >
   <vendor type="mysql">
       <parameter name="Engine" value="InnoDB"/>
       <parameter name="Charset" value="utf8"/>
   </vendor>
   <column name="status" type="enum" valueSet="a,b,c" description="some desc"/>
</table>
```

diff task always include this table in migration class (and there is always a migration class) 
The problem is, In PropelColumnComparator::compareColumns from domain is some thing like this : 

```
Domain Object
(
    [name:Domain:private] => 
    [description:Domain:private] => 
    [size:Domain:private] => 
    [scale:Domain:private] => 
    [propelType:Domain:private] => TINYINT
    [sqlType:Domain:private] => TINYINT
    [defaultValue:Domain:private] => 
    [database:Domain:private] => 
    [attributes:protected] => Array
        (
        )

    [vendorInfos:protected] => Array
        (
        )

)
```

But toDomain is like this : 

```
Domain Object
(
    [name:Domain:private] => 
    [description:Domain:private] => 
    [size:Domain:private] => 
    [scale:Domain:private] => 
    [propelType:Domain:private] => ENUM
    [sqlType:Domain:private] => TINYINT
    [defaultValue:Domain:private] => 
    [database:Domain:private] => 
    [attributes:protected] => Array
        (
        )

    [vendorInfos:protected] => Array
        (
        )

)
```

The propelType in From field is TINYINT but in to ENUM  (its default in propel as I know) so the compare always return this as diff. 

This also happen when there is a default value in enum fields. 
