### PR TITLE
Possibility to use migrations in parallel feature branches

### DIFF
--- a/generator/lib/task/PropelMigrationDownTask.php
+++ b/generator/lib/task/PropelMigrationDownTask.php
@@ -89,7 +89,7 @@ class PropelMigrationDownTask extends BasePropelMigrationTask
                 $datasource
             ));
 
-            $manager->updateLatestMigrationTimestamp($datasource, $previousTimestamp);
+            $manager->removeMigrationTimestamp($datasource, $nextMigrationTimestamp);
             $this->log(sprintf(
                 'Downgraded migration date to %d for datasource "%s"',
                 $previousTimestamp,

--- a/generator/lib/task/PropelMigrationStatusTask.php
+++ b/generator/lib/task/PropelMigrationStatusTask.php
@@ -74,12 +74,13 @@ class PropelMigrationStatusTask extends BasePropelMigrationTask
                 }
             }
             foreach ($migrationTimestamps as $timestamp) {
+                $executed = !in_array($timestamp, $validTimestamps);
                 $this->log(sprintf(
                     ' %s %s %s',
                     $timestamp == $oldestMigrationTimestamp ? '>' : ' ',
                     $manager->getMigrationClassName($timestamp),
-                    $timestamp <= $oldestMigrationTimestamp ? '(executed)' : ''
-                ), $timestamp <= $oldestMigrationTimestamp ? Project::MSG_VERBOSE : Project::MSG_INFO);
+                    $executed ? '(executed)' : ''
+                ), $executed ? Project::MSG_VERBOSE : Project::MSG_INFO);
             }
         } else {
             $this->log(sprintf('No migration file found in "%s".', $dir));

--- a/generator/lib/util/PropelMigrationManager.php
+++ b/generator/lib/util/PropelMigrationManager.php
@@ -129,7 +129,7 @@ class PropelMigrationManager
         $migrationTimestamps = array();
         foreach ($connections as $name => $params) {
             $pdo = $this->getPdoConnection($name);
-            $sql = sprintf('SELECT version FROM %s', $this->getMigrationTable());
+            $sql = sprintf('SELECT version FROM %s ORDER BY version DESC LIMIT 1', $this->getMigrationTable());
 
             try {
                 $stmt = $pdo->prepare($sql);
@@ -148,6 +148,32 @@ class PropelMigrationManager
         }
 
         return $oldestMigrationTimestamp;
+    }
+
+    public function getAllDatabaseVersions()
+    {
+        if (!$connections = $this->getConnections()) {
+            throw new Exception('You must define database connection settings in a buildtime-conf.xml file to use migrations');
+        }
+        $migrationTimestamps = array();
+        foreach ($connections as $name => $params) {
+            $pdo = $this->getPdoConnection($name);
+            $sql = sprintf('SELECT version FROM %s', $this->getMigrationTable());
+
+            try {
+                $stmt = $pdo->prepare($sql);
+                $stmt->execute();
+                while ($migrationTimestamp = $stmt->fetchColumn()) {
+                    $migrationTimestamps[] = $migrationTimestamp;
+                }
+            } catch (PDOException $e) {
+                $this->createMigrationTable($name);
+                $migrationTimestamps = array();
+            }
+        }
+        sort($migrationTimestamps);
+
+        return $migrationTimestamps;
     }
 
     public function migrationTableExists($datasource)
@@ -189,11 +215,21 @@ class PropelMigrationManager
     {
         $platform = $this->getPlatform($datasource);
         $pdo = $this->getPdoConnection($datasource);
-        $sql = sprintf('DELETE FROM %s', $this->getMigrationTable());
-        $pdo->beginTransaction();
-        $stmt = $pdo->prepare($sql);
-        $stmt->execute();
         $sql = sprintf('INSERT INTO %s (%s) VALUES (?)',
+            $this->getMigrationTable(),
+            $platform->quoteIdentifier('version')
+        );
+        $stmt = $pdo->prepare($sql);
+        $stmt->bindParam(1, $timestamp, PDO::PARAM_INT);
+        $stmt->execute();
+        $pdo->commit();
+    }
+
+    public function removeMigrationTimestamp($datasource, $timestamp)
+    {
+        $platform = $this->getPlatform($datasource);
+        $pdo = $this->getPdoConnection($datasource);
+        $sql = sprintf('DELETE FROM %s WHERE %s = ?',
             $this->getMigrationTable(),
             $platform->quoteIdentifier('version')
         );
@@ -222,14 +258,7 @@ class PropelMigrationManager
 
     public function getValidMigrationTimestamps()
     {
-        $oldestMigrationTimestamp = $this->getOldestDatabaseVersion();
-        $migrationTimestamps = $this->getMigrationTimestamps();
-        // removing already executed migrations
-        foreach ($migrationTimestamps as $key => $timestamp) {
-            if ($timestamp <= $oldestMigrationTimestamp) {
-                unset($migrationTimestamps[$key]);
-            }
-        }
+        $migrationTimestamps = array_diff($this->getMigrationTimestamps(), $this->getAllDatabaseVersions());
         sort($migrationTimestamps);
 
         return $migrationTimestamps;
@@ -242,14 +271,7 @@ class PropelMigrationManager
 
     public function getAlreadyExecutedMigrationTimestamps()
     {
-        $oldestMigrationTimestamp = $this->getOldestDatabaseVersion();
-        $migrationTimestamps = $this->getMigrationTimestamps();
-        // removing already executed migrations
-        foreach ($migrationTimestamps as $key => $timestamp) {
-            if ($timestamp > $oldestMigrationTimestamp) {
-                unset($migrationTimestamps[$key]);
-            }
-        }
+        $migrationTimestamps = array_intersect($this->getMigrationTimestamps(), $this->getAllDatabaseVersions());
         sort($migrationTimestamps);
 
         return $migrationTimestamps;


### PR DESCRIPTION
During executing migrations store not only latest migration timestamp, but all timestamps of executed migrations. It allows to execute all migrations after merging two or more feature branches with migrations which were developed at the same time.

Before use you should import into propel_migration table timestamps of all already executed migrations.
