### PR TITLE
DebugPDO executedQueryString - quoting

### DIFF
--- a/test/testsuite/runtime/connection/PropelPDOTest.php
+++ b/test/testsuite/runtime/connection/PropelPDOTest.php
@@ -457,6 +457,206 @@ class PropelPDOTest extends PHPUnit_Framework_TestCase
         $con->setLogger($logger);
         $config->setParameter("debugpdo.logging.methods", array('PropelPDO::exec', 'PropelPDO::query', 'DebugPDOStatement::execute'));
     }
+
+    /**
+     * Testing if string values will be quoted correctly by DebugPDOStatement::getExecutedQueryString
+     */
+    public function testDebugExecutedQueryStringValue()
+    {
+
+        /**
+         * @var DebugPDO $con
+         */
+        $con = Propel::getConnection(BookPeer::DATABASE_NAME);
+
+        // different method must all result in this given querystring, using a string value
+        $bindParamStringValue = "%Harry%";
+        $expectedQuery = "SELECT book.id FROM `book` WHERE book.title LIKE '{$bindParamStringValue}'";
+
+        // simple statement without params
+        $prepStmt = $con->prepare($expectedQuery);
+        $prepStmt->execute();
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // statement with named placeholder
+        $prepStmt = $con->prepare("SELECT book.id FROM `book` WHERE book.title LIKE :p1");
+        $prepStmt->bindValue(':p1', '%Harry%'); // bind value variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        $prepStmt->bindParam(':p1', $bindParamStringValue); // bind param variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // passing params directly
+        $prepStmt->execute(array(':p1' => '%Harry%'));
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+
+        // statement with named placeholder, this one won't get substituted
+        $expectedNotSubstitutedQuery = "SELECT book.id FROM `book` WHERE book.title LIKE :name";
+        $prepStmt = $con->prepare($expectedNotSubstitutedQuery);
+        $prepStmt->bindValue(':name', '%Harry%'); // bind value variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        $prepStmt->bindParam(':name', $bindParamStringValue); // bind param variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // passing params directly
+        $prepStmt->execute(array(':name' => '%Harry%'));
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+
+        // statement with positional placeholder, this one won't get substituted either
+        $expectedNotSubstitutedQuery = "SELECT book.id FROM `book` WHERE book.title LIKE ?";
+        $prepStmt = $con->prepare($expectedNotSubstitutedQuery);
+        $prepStmt->bindValue(1, '%Harry%');
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        $prepStmt->bindParam(1, $bindParamStringValue);
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // passing params directly
+        $prepStmt->execute(array('%Harry%'));
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+    }
+
+    /**
+     * Testing if integer values will be quoted correctly by DebugPDOStatement::getExecutedQueryString
+     */
+    public function testDebugExecutedQueryIntegerValue() {
+
+        /**
+         * @var DebugPDO $con
+         */
+        $con = Propel::getConnection(BookPeer::DATABASE_NAME);
+
+        // different method must all result in this given querystring, using an integer value
+        $bindParamIntegerValue = 123;
+        $expectedQuery = "SELECT book.title FROM `book` WHERE book.id = {$bindParamIntegerValue}";
+
+        // simple statement without params
+        $prepStmt = $con->prepare($expectedQuery);
+        $prepStmt->execute();
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // statement with named placeholder
+        $prepStmt = $con->prepare("SELECT book.title FROM `book` WHERE book.id = :p1");
+        $prepStmt->bindValue(':p1', 123); // bind value variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        $prepStmt->bindParam(':p1', $bindParamIntegerValue); // bind param variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // passing params directly
+        $prepStmt->execute(array(':p1' => 123));
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+
+        // statement with named placeholder, this one won't get substituted
+        $expectedNotSubstitutedQuery = "SELECT book.title FROM `book` WHERE book.id = :name";
+        $prepStmt = $con->prepare($expectedNotSubstitutedQuery);
+        $prepStmt->bindValue(':name', 123); // bind value variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        $prepStmt->bindParam(':name', $bindParamIntegerValue); // bind param variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // passing params directly
+        $prepStmt->execute(array(':name' => 123));
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+
+        // statement with positional placeholder, this one won't get substituted either
+        $expectedNotSubstitutedQuery = "SELECT book.title FROM `book` WHERE book.id = ?";
+        $prepStmt = $con->prepare($expectedNotSubstitutedQuery);
+        $prepStmt->bindValue(1, 123);
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        $prepStmt->bindParam(1, $bindParamIntegerValue);
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // passing params directly
+        $prepStmt->execute(array(123));
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+    }
+
+    /**
+     * Testing if numeric values will be quoted correctly by DebugPDOStatement::getExecutedQueryString
+     * Numeric values sometimes will get handled differently, since there are numeric values which are non-integer
+     */
+    public function testDebugExecutedQueryNumericValue() {
+
+        /**
+         * @var DebugPDO $con
+         */
+        $con = Propel::getConnection(BookPeer::DATABASE_NAME);
+
+        // different method must all result in this given querystring, using an integer value
+        $bindParamNumericValue = 0002000;
+        $expectedQuery = "SELECT book.title FROM `book` WHERE book.id = {$bindParamNumericValue}";
+
+        // simple statement without params
+        $prepStmt = $con->prepare($expectedQuery);
+        $prepStmt->execute();
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // statement with named placeholder
+        $prepStmt = $con->prepare("SELECT book.title FROM `book` WHERE book.id = :p1");
+        $prepStmt->bindValue(':p1', 0002000); // bind value variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        $prepStmt->bindParam(':p1', $bindParamNumericValue); // bind param variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // passing params directly
+        $prepStmt->execute(array(':p1' => 0002000));
+        $this->assertEquals($expectedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+
+        // statement with named placeholder, this one won't get substituted
+        $expectedNotSubstitutedQuery = "SELECT book.title FROM `book` WHERE book.id = :name";
+        $prepStmt = $con->prepare($expectedNotSubstitutedQuery);
+        $prepStmt->bindValue(':name', 0002000); // bind value variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        $prepStmt->bindParam(':name', $bindParamNumericValue); // bind param variant
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // passing params directly
+        $prepStmt->execute(array(':name' => 0002000));
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+
+        // statement with positional placeholder, this one won't get substituted either
+        $expectedNotSubstitutedQuery = "SELECT book.title FROM `book` WHERE book.id = ?";
+        $prepStmt = $con->prepare($expectedNotSubstitutedQuery);
+        $prepStmt->bindValue(1, 0002000);
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        $prepStmt->bindParam(1, $bindParamNumericValue);
+        $prepStmt->execute();
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+
+        // passing params directly
+        $prepStmt->execute(array(0002000));
+        $this->assertEquals($expectedNotSubstitutedQuery, $con->getLastExecutedQuery(), 'DebugPDO failed to quote prepared statement on execute properly');
+    }
 }
 
 class myLogger

--- a/test/testsuite/runtime/query/ModelCriteriaTest.php
+++ b/test/testsuite/runtime/query/ModelCriteriaTest.php
@@ -326,7 +326,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         );
         $this->assertCriteriaTranslation($c, $sql, $params, 'where() accepts a complex calculation');
         $c->find($this->con);
-        $expected = "SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM `book` WHERE LOCATE('foo', book.title) = true";
+        $expected = "SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM `book` WHERE LOCATE('foo', book.title) = 1";
         $this->assertEquals($expected, $this->con->getLastExecutedQuery());
     }
 


### PR DESCRIPTION
When displaying executed query from DebugPDO (i.e. in FirePHP), sometimes the outputted query is not valid. 
This can be fixed with a simple quoting in DebugPDOStatement class.

Before: http://d.pr/i/Mgyi
After: http://d.pr/i/Xx6X

Some examples:

// works without change
$con = Propel::getConnection();
$con->query("SELECT \* FROM temp WHERE name LIKE '%david%'");

// also works
$prepStmt = $con->prepare("SELECT \* FROM temp WHERE name LIKE :name");
$prepStmt->bindValue('name', '%david%');
$prepStmt->execute();

// does not work, since params get quoted different
$con = Propel::getConnection();
$prepStmt = $con->prepare("SELECT \* FROM temp WHERE name LIKE :p1");
$prepStmt->execute(array(':p1' => '%john%'));
