### PR TITLE
Update mastering-symfony2-forms-with-propel.markdown

### DIFF
--- a/cookbook/symfony2/mastering-symfony2-forms-with-propel.markdown
+++ b/cookbook/symfony2/mastering-symfony2-forms-with-propel.markdown
@@ -524,7 +524,7 @@ In order to validate the unicity of more than just one fields:
 BundleNamespace\Model\User:
   constraints:
     - Propel\PropelBundle\Validator\Constraints\UniqueObject:
-      fields: [username, login]
+        fields: [username, login]
 {% endhighlight %}
 
 As many validator of this type as you want can be used.


### PR DESCRIPTION
There's an error fixed in yaml file. Missing spaces causes yaml file not to validate properly
