### PR TITLE
Honour value of Timestampable's "disable_updated_at" parameter in SoftDeleteBehavior

### DIFF
--- a/generator/lib/behavior/SoftDeleteBehavior.php
+++ b/generator/lib/behavior/SoftDeleteBehavior.php
@@ -94,7 +94,7 @@ public function unDelete(PropelPDO \$con = null)
         $script = "if (!empty(\$ret) && {$builder->getStubQueryBuilder()->getClassname()}::isSoftDeleteEnabled()) {";
 
         // prevent updated_at from changing when using a timestampable behavior
-        if ($this->getTable()->hasBehavior('timestampable')) {
+        if ($this->getTable()->hasBehavior('timestampable') && ($this->getTable()->getBehavior('timestampable')->getParameter('disable_updated_at') === 'false')) {
             $script .= "
     \$this->keepUpdateDateUnchanged();";
         }


### PR DESCRIPTION
The SoftDeleteBehavior does not honour the value of the "disable_updated_at" parameter in the Timestampable behaviour. 

If "disable_updated_at" is set to "true" this results in the delete() method in BaseXXX.php classes being generated with a call to 

``` php
$this->keepUpdateDateUnchanged();
```

which result in Fatal Errors when trying to perform a delete due to the method not existing.

I realise that SoftDelete is deprecated but many users are still using it and this tiny fix would be very helpful for us!
