### PR TITLE
Update to the Propel::getConfiguration() method

### DIFF
--- a/runtime/lib/Propel.php
+++ b/runtime/lib/Propel.php
@@ -378,7 +378,11 @@ class Propel
      */
     public static function getConfiguration($type = PropelConfiguration::TYPE_ARRAY)
     {
-        return self::$configuration->getParameters($type);
+        if( self::$configuration instanceof PropelConfiguration ){
+            return self::$configuration->getParameters($type);
+        }else{
+            return self::$configuration;
+        }
     }
 
     /**

--- a/runtime/lib/Propel.php
+++ b/runtime/lib/Propel.php
@@ -374,15 +374,11 @@ class Propel
      *                   ($config['name.space.item'])
      *                 - PropelConfiguration::TYPE_OBJECT: return the configuration as a PropelConfiguration instance
      *
-     * @return mixed The Configuration (array or PropelConfiguration)
+     * @return mixed The Configuration (array, PropelConfiguration or null if ther's not configuration yet).
      */
     public static function getConfiguration($type = PropelConfiguration::TYPE_ARRAY)
     {
-        if( self::$configuration instanceof PropelConfiguration ){
-            return self::$configuration->getParameters($type);
-        }else{
-            return self::$configuration;
-        }
+        return self::$configuration ? self::$configuration->getParameters($type) : null;
     }
 
     /**

--- a/runtime/lib/formatter/PropelObjectFormatter.php
+++ b/runtime/lib/formatter/PropelObjectFormatter.php
@@ -20,7 +20,7 @@ class PropelObjectFormatter extends PropelFormatter
 {
     protected $collectionName = 'PropelObjectCollection';
 
-    protected $mainObject;
+    private $mainObject;
 
     public function format(PDOStatement $stmt)
     {

--- a/runtime/lib/formatter/PropelObjectFormatter.php
+++ b/runtime/lib/formatter/PropelObjectFormatter.php
@@ -20,7 +20,7 @@ class PropelObjectFormatter extends PropelFormatter
 {
     protected $collectionName = 'PropelObjectCollection';
 
-    private $mainObject;
+    protected $mainObject;
 
     public function format(PDOStatement $stmt)
     {


### PR DESCRIPTION
Update to the Propel::getConfiguration() method to avoid: "Fatal error: Call to a member function getParameters() on a non-object".
This error occurs because we didn't call Propel::setConfiguration() before calling Propel::getConfiguration().
In my opinion this function should return null (the default value of the configuration class property) instead of an untreated error (fatal error).
