### PR TITLE
Fix for migrate connection error

### DIFF
--- a/runtime/lib/Propel.php
+++ b/runtime/lib/Propel.php
@@ -648,7 +648,7 @@ class Propel
      */
     public static function initConnection($conparams, $name, $defaultClass = Propel::CLASS_PROPEL_PDO)
     {
-        $adapter = self::getDB($name);
+        $adapter = isset($conparams['adapter']) ? DBAdapter::factory($conparams['adapter']) : self::getDB($name);
 
         if (null === $conparams['dsn']) {
             throw new PropelException('No dsn specified in your connection parameters for datasource [' . $name . ']');


### PR DESCRIPTION
Fixes issue #741 
This issue is a real show-stopper in 1.7. It completely breaks migrations for us. We are currently having to run off this branch of the 1.7.1 tag in order to use Propel.

Credit for fix: https://github.com/jh-ism-online-webmaster/Propel/commit/846640a8d00a01c462c3dc78969afa2931e75b54
