### PR TITLE
Ternary operator supported only in php5.3+

### DIFF
--- a/runtime/lib/connection/DebugPDOStatement.php
+++ b/runtime/lib/connection/DebugPDOStatement.php
@@ -101,7 +101,7 @@ class DebugPDOStatement extends PDOStatement
         $debug = $this->pdo->getDebugSnapshot();
         $return = parent::execute($input_parameters);
 
-        $sql = $this->getExecutedQueryString($input_parameters?:array());
+        $sql = $this->getExecutedQueryString($input_parameters?$input_parameters:array());
         $this->pdo->log($sql, null, __METHOD__, $debug);
         $this->pdo->setLastExecutedQuery($sql);
         $this->pdo->incrementQueryCount();


### PR DESCRIPTION
Fixes compatibility with php 5.2, as the Docs still say that propel requires 5.2.4+ version, ternary operators should not be used.
