### PR TITLE
isVersioningNecessary always uses default connection

### DIFF
--- a/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -101,7 +101,7 @@ class VersionableBehaviorObjectBuilderModifier
 
     public function preSave(PHP5ObjectBuilder $builder)
     {
-        $script = "if (\$this->isVersioningNecessary()) {
+        $script = "if (\$this->isVersioningNecessary(\$con)) {
     \$this->set{$this->getColumnPhpName()}(\$this->isNew() ? 1 : \$this->getLastVersionNumber(\$con) + 1);";
         if ($this->behavior->getParameter('log_created_at') == 'true') {
             $col = $this->behavior->getTable()->getColumn($this->getParameter('version_created_at_column'));


### PR DESCRIPTION
Added missing $con variable, isVersioningNecessary doesn't use passed in connection and always connects to default connection