### PR TITLE
Versionable Behaviour : 2nd bug with multiple identical related objects

### DIFF
--- a/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -350,6 +350,7 @@ public function addVersion(\$con = null)
         \$version->set{$fkVersionColumnPhpName}(\$related->getVersion());
     }";
         }
+
         foreach ($this->behavior->getVersionableReferrers() as $fk) {
             if ($fk->isLocalPrimaryKey()) {
                 $fkGetter = $this->builder->getRefFKPhpNameAffix($fk);
@@ -364,10 +365,16 @@ public function addVersion(\$con = null)
                 $fkGetter = $this->builder->getRefFKPhpNameAffix($fk, $plural = true);
                 $idsColumn = $this->behavior->getReferrerIdsColumn($fk);
                 $versionsColumn = $this->behavior->getReferrerVersionsColumn($fk);
+                $idColumnName = rtrim($idsColumn->getPhpName(), 's');
+                $versionColumnName = rtrim($versionsColumn->getPhpName(), 's');
                 $script .= "
     if (\$relateds = \$this->get{$fkGetter}(\$con)->toKeyValue('{$fk->getTable()->getFirstPrimaryKeyColumn()->getPhpName()}', 'Version')) {
-        \$version->set{$idsColumn->getPhpName()}(array_keys(\$relateds));
-        \$version->set{$versionsColumn->getPhpName()}(array_values(\$relateds));
+        foreach(array_keys(\$relateds) as \$id) {
+            \$version->add{$idColumnName}(\$id);
+        }
+        foreach(array_values(\$relateds) as \$version_num) {
+            \$version->add{$versionColumnName}(\$version_num);
+        }
     }";
             }
         }


### PR DESCRIPTION
This PR is related with this one :
https://github.com/propelorm/Propel/pull/876

Still the same example, one contract, 2 companies. Here is the generated code in BaseCompany.php

``` php
public function addVersion($con = null)
{
...
   $version->setCompany($this);
   if ($relateds = $this->getContractsRelatedByRenterCompanyId($con)->toKeyValue('Id', 'Version')) {
      $version->setContractIds(array_keys($relateds));
      $version->setContractVersions(array_values($relateds));
   }
   if ($relateds = $this->getContractsRelatedByTenantCompanyId($con)->toKeyValue('Id', 'Version')) {
      $version->setContractIds(array_keys($relateds));
      $version->setContractVersions(array_values($relateds));
   }
   $version->save($con);
...
```

If I have a company that is both refered as a tenant and a renter, the second if block will override contract ids set to version.

The correction I propose use add instead of set so the generated code looks like

``` php
...
$version->setCompany($this);
if ($relateds = $this->getContractsRelatedByRenterCompanyId($con)->toKeyValue('Id', 'Version')) {
    foreach(array_keys($relateds) as $id) {
        $version->addContractId($id);
    }
    foreach(array_values($relateds) as $version_num) {
        $version->addContractVersion($version_num);
    }
}
if ($relateds = $this->getContractsRelatedByTenantCompanyId($con)->toKeyValue('Id', 'Version')) {
    foreach(array_keys($relateds) as $id) {
        $version->addContractId($id);
    }
    foreach(array_values($relateds) as $version_num) {
        $version->addContractVersion($version_num);
    }
}
$version->save($con);
...
```
