### PR TITLE
Fix bug in object builder where a connection is not propel injected.

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -3940,7 +3940,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
             }
 
             if (\$partial && !\$criteria) {
-                return count(\$this->get$relCol());
+                return count(\$this->get$relCol(NULL, \$con));
             }
             \$query = $fkQueryClassname::create(null, \$criteria);
             if (\$distinct) {


### PR DESCRIPTION
I discovered this bug when testing something in our app, it's just a missing connection injection which will cause the countREL() generated functions to make the query on the wrong connection and return unexpected/incorrect results.
