### PR TITLE
Changed collections model var to fully qualified classname.

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -3847,7 +3847,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
             return;
         }
         \$this->$collName = new PropelObjectCollection();
-        \$this->{$collName}->setModel('" . $this->getNewStubObjectBuilder($refFK->getTable())->getClassname() . "');
+        \$this->{$collName}->setModel('" . $this->getNewStubObjectBuilder($refFK->getTable())->getFullyQualifiedClassname() . "');
     }
 ";
     } // addRefererInit()


### PR DESCRIPTION
Changed the class name of models related collections to be the fully qualified class name instead of the simple one. This helps (makes code not crash) when dynamically instantiating the class from code outside the BaseModel file.
For some reason also helps when running method_exists on objects inside collections created from this code.