### PR TITLE
check which primary key is auto increment

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -5071,7 +5071,11 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
 
         // if auto-increment, get the id after
         if ($platform->isNativeIdMethodAutoIncrement() && $table->getIdMethod() == "native") {
-            $column = $table->getFirstPrimaryKeyColumn();
+            foreach($table->getPrimaryKey() as $column) {
+                if(!$column->isAutoIncrement()) {
+                    continue;
+                }
+            }
             $columnProperty = strtolower($column->getName());
             $script .= "
         try {";


### PR DESCRIPTION
When the auto increment is not set on the first key of the primary there is a bug. 

Having a structure where the first key of a primary key is fixe (like a user_id for example) and the second auto-increment is a optimization for search query base on the first primary key entry.
