### PR TITLE
Missing several parentheses in code examples

### DIFF
--- a/cookbook/symfony2/mastering-symfony2-forms-with-propel.markdown
+++ b/cookbook/symfony2/mastering-symfony2-forms-with-propel.markdown
@@ -235,7 +235,7 @@ class AuthorType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => 'Acme\LibraryBundle\Model\Author',
-        );
+        ));
     }
 
     public function getName()
@@ -283,7 +283,7 @@ class AuthorType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => 'Acme\LibraryBundle\Model\Author',
-        );
+        ));
     }
 
     public function getName()
@@ -317,7 +317,7 @@ class BookType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => 'Acme\LibraryBundle\Model\Book',
-        );
+        ));
     }
 
     public function getName()
@@ -391,7 +391,7 @@ class BookClubListType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => 'Acme\LibraryBundle\Model\BookClubList',
-        );
+        ));
     }
 
     public function getName()
@@ -450,7 +450,7 @@ class BookType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => 'Acme\LibraryBundle\Model\Book',
-        );
+        ));
     }
 
     public function getName()


### PR DESCRIPTION
There are several instances of the examples where a second parentheses is missing in the setDefaultOptions method.
