### PR TITLE
removed namespace backslash

### DIFF
--- a/generator/lib/behavior/sluggable/SluggableBehavior.php
+++ b/generator/lib/behavior/sluggable/SluggableBehavior.php
@@ -98,7 +98,7 @@ if (\$this->isColumnModified($const) && \$this->{$this->getColumnGetter()}()) {
                     $column = $i18n->getI18nTable()->getColumn($columnName);
                 }
                 if (null == $column) {
-                    throw new \InvalidArgumentException(sprintf('The pattern %s is invalid  the column %s is not found', $pattern, $match));
+                    throw new InvalidArgumentException(sprintf('The pattern %s is invalid  the column %s is not found', $pattern, $match));
                 }
                 $columnConst = $builder->getColumnConstant($column);
                 $script .= "\$this->isColumnModified($columnConst)" . ($key < $count - 1 ? " || " : "");


### PR DESCRIPTION
Incompatible with php 5.2
Warning: Unexpected character in input:  '\' (ASCII=92) state=1 in ..\propel\generator\lib\behavior\sluggable\SluggableBehavior.php on line 97