### PR TITLE
Fix support of baseClass attribute for table with namespaces.

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -201,13 +201,14 @@ class PHP5ObjectBuilder extends ObjectBuilder
         $tableDesc = $table->getDescription();
         $parentClass = $this->getBehaviorContent('parentClass');
         if (null === $parentClass) {
-            $parentClass = ClassTools::classname($this->getBaseClass());
+          $parentClass = ClassTools::classname($this->getBaseClass());
 
-            if (false === strpos($this->getBaseClass(), '.')) {
-                $this->declareClass($this->getBaseClass());
-            } else {
-                $this->declareClass($parentClass);
-            }
+          if (false === strpos($this->getBaseClass(), '.') || 'BaseObject' === $parentClass) {
+            $this->declareClass($parentClass);
+          } else {
+            $parentClassFQCN = '\\'.str_replace('.', '\\', $this->getBaseClass());
+            $this->declareClass($parentClassFQCN);
+          }
         }
 
         if ($this->getBuildProperty('addClassLevelComment')) {

--- a/test/testsuite/generator/builder/om/PHP5ObjectBuilderTest.php
+++ b/test/testsuite/generator/builder/om/PHP5ObjectBuilderTest.php
@@ -66,6 +66,24 @@ class PHP5ObjectBuilderTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals('TYPE_PHPNAME', $this->builder->getDefaultKeyType());
     }
+
+    public function testBaseClassWithNamespace()
+    {
+	    // we need a class we can inherit, and that class must extend \BaseObject
+	    eval('namespace Foo\Bar;class Baz extends \BaseObject {}');
+
+	    $schema = <<<EOF
+<database name="simple_database">
+    <table name="inheriting_table" baseClass='Foo.Bar.Baz'>
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
+    </table>
+</database>
+EOF;
+
+	    $builder = new PropelQuickBuilder();
+	    $builder->setSchema($schema);
+	    $builder->build(); // this call fatals without the code implementing namespaces
+    }
 }
 
 class TestablePHP5ObjectBuilder extends PHP5ObjectBuilder
@@ -74,4 +92,9 @@ class TestablePHP5ObjectBuilder extends PHP5ObjectBuilder
     {
         return parent::getDefaultValueString($col);
     }
+
+	  public function addClassOpen(&$script)
+	  {
+		  parent::addClassOpen($script);
+	  }
 }


### PR DESCRIPTION
Fixes issue #209. Format is simply dotted notation, eg.

```
<database name="simple_database">
    <table name="inheriting_table" baseClass='Foo.Bar.Baz'>
        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
    </table>
</database>
```

Note that the table inherited must extend \BaseObject
