### PR TITLE
Fix identifier quoting on Oracle/Postgres

### DIFF
--- a/runtime/lib/adapter/DBOracle.php
+++ b/runtime/lib/adapter/DBOracle.php
@@ -306,4 +306,23 @@ class DBOracle extends DBAdapter
 FROM PLAN_TABLE CONNECT BY PRIOR ID = PARENT_ID AND PRIOR STATEMENT_ID = STATEMENT_ID
 START WITH ID = 0 AND STATEMENT_ID = \'%s\' ORDER BY ID', $uniqueId);
     }
+
+    /**
+     * Quote identifier only when needed
+     *
+     *  We don't like to quote aliases on Oracle, so this is how we get around it, quoting only when a dot/space is there
+     *
+     * @return string
+     */
+    public function quoteIdentifier($text)
+    {
+        if (false === strpos($text, '.')
+            && false === strpos($text, ' ')
+        ) {
+            return $text;
+        }
+
+        return parent::quoteIdentifier($text);
+    }
+
 }

--- a/runtime/lib/adapter/DBOracle.php
+++ b/runtime/lib/adapter/DBOracle.php
@@ -316,9 +316,7 @@ START WITH ID = 0 AND STATEMENT_ID = \'%s\' ORDER BY ID', $uniqueId);
      */
     public function quoteIdentifier($text)
     {
-        if (false === strpos($text, '.')
-            && false === strpos($text, ' ')
-        ) {
+        if (ctype_alnum($text)) {
             return $text;
         }
 

--- a/runtime/lib/adapter/DBPostgres.php
+++ b/runtime/lib/adapter/DBPostgres.php
@@ -259,9 +259,7 @@ class DBPostgres extends DBAdapter
      */
     public function quoteIdentifier($text)
     {
-        if (false === strpos($text, '.')
-            && false === strpos($text, ' ')
-        ) {
+        if (ctype_alnum($text)) {
             return $text;
         }
 

--- a/runtime/lib/adapter/DBPostgres.php
+++ b/runtime/lib/adapter/DBPostgres.php
@@ -249,4 +249,23 @@ class DBPostgres extends DBAdapter
     {
         return 'EXPLAIN ' . $query;
     }
+
+    /**
+     * Quote identifier only when needed
+     *
+     *  We don't like to quote aliases on Postgres, so this is how we get around it, quoting only when a dot/space is there
+     *
+     * @return string
+     */
+    public function quoteIdentifier($text)
+    {
+        if (false === strpos($text, '.')
+            && false === strpos($text, ' ')
+        ) {
+            return $text;
+        }
+
+        return parent::quoteIdentifier($text);
+    }
+
 }

--- a/test/testsuite/runtime/adapter/DBOracleTest.php
+++ b/test/testsuite/runtime/adapter/DBOracleTest.php
@@ -86,7 +86,8 @@ class DBOracleTest extends DBAdapterTestAbstract
     {
         $db = new DBOracle();
         $this->assertEquals('"Book ISBN"', $db->quoteIdentifier('Book ISBN'));
-
-        $this->assertEquals('foo', $db->quoteIdentifier('foo'), 'identifier without <space>/. should not be quoted');
+        $this->assertEquals('"propel.book"', $db->quoteIdentifier('propel.book'));
+        $this->assertEquals('"some$string"', $db->quoteIdentifier('some$string'));
+        $this->assertEquals('foo1', $db->quoteIdentifier('foo1'), 'identifier with alphanum only should not be quoted');
     }
 }

--- a/test/testsuite/runtime/adapter/DBOracleTest.php
+++ b/test/testsuite/runtime/adapter/DBOracleTest.php
@@ -84,7 +84,7 @@ class DBOracleTest extends DBAdapterTestAbstract
 
     public function testQuotingIdentifiers()
     {
-        $db = new DBPostgres();
+        $db = new DBOracle();
         $this->assertEquals('"Book ISBN"', $db->quoteIdentifier('Book ISBN'));
 
         $this->assertEquals('foo', $db->quoteIdentifier('foo'), 'identifier without <space>/. should not be quoted');

--- a/test/testsuite/runtime/adapter/DBOracleTest.php
+++ b/test/testsuite/runtime/adapter/DBOracleTest.php
@@ -84,7 +84,9 @@ class DBOracleTest extends DBAdapterTestAbstract
 
     public function testQuotingIdentifiers()
     {
-        $db = new DBOracle();
+        $db = new DBPostgres();
         $this->assertEquals('"Book ISBN"', $db->quoteIdentifier('Book ISBN'));
+
+        $this->assertEquals('foo', $db->quoteIdentifier('foo'), 'identifier without <space>/. should not be quoted');
     }
 }

--- a/test/testsuite/runtime/adapter/DBPostgresTest.php
+++ b/test/testsuite/runtime/adapter/DBPostgresTest.php
@@ -29,9 +29,11 @@ class DBPostgresTest extends DBAdapterTestAbstract
     $this->assertEquals('EXPLAIN SELECT B.* FROM (SELECT A.*, rownum AS PROPEL_ROWNUM FROM (SELECT book.ID AS ORA_COL_ALIAS_0, book.TITLE AS ORA_COL_ALIAS_1, book.ISBN AS ORA_COL_ALIAS_2, book.PRICE AS ORA_COL_ALIAS_3, book.PUBLISHER_ID AS ORA_COL_ALIAS_4, book.AUTHOR_ID AS ORA_COL_ALIAS_5, author.ID AS ORA_COL_ALIAS_6, author.FIRST_NAME AS ORA_COL_ALIAS_7, author.LAST_NAME AS ORA_COL_ALIAS_8, author.EMAIL AS ORA_COL_ALIAS_9, author.AGE AS ORA_COL_ALIAS_10, book.PRICE AS BOOK_PRICE FROM book, author) A ) B WHERE  B.PROPEL_ROWNUM <= 1', $db->getExplainPlanQuery($query), 'getExplainPlanQuery() returns a SQL Explain query');
   }
 
-  public function testQuotingIdentifiers()
-  {
-    $db = new DBPostgres();
-    $this->assertEquals('"Book ISBN"', $db->quoteIdentifier('Book ISBN'));
-  }
+    public function testQuotingIdentifiers()
+    {
+        $db = new DBPostgres();
+        $this->assertEquals('"Book ISBN"', $db->quoteIdentifier('Book ISBN'));
+
+        $this->assertEquals('foo', $db->quoteIdentifier('foo'), 'identifier without <space>/. should not be quoted');
+    }
 }

--- a/test/testsuite/runtime/adapter/DBPostgresTest.php
+++ b/test/testsuite/runtime/adapter/DBPostgresTest.php
@@ -32,8 +32,10 @@ class DBPostgresTest extends DBAdapterTestAbstract
     public function testQuotingIdentifiers()
     {
         $db = new DBPostgres();
-        $this->assertEquals('"Book ISBN"', $db->quoteIdentifier('Book ISBN'));
 
-        $this->assertEquals('foo', $db->quoteIdentifier('foo'), 'identifier without <space>/. should not be quoted');
+        $this->assertEquals('"Book ISBN"', $db->quoteIdentifier('Book ISBN'));
+        $this->assertEquals('"propel.book"', $db->quoteIdentifier('propel.book'));
+        $this->assertEquals('"some$string"', $db->quoteIdentifier('some$string'));
+        $this->assertEquals('foo1', $db->quoteIdentifier('foo1'), 'identifier with alphanum only should not be quoted');
     }
 }


### PR DESCRIPTION
This fixes issue #885
Oracle and Postgres (at least) don't like to have quoted alias when trying
to group by them. This fix gets around the issue by quoting only identifiers
that have a space/dot in them.
