### PR TITLE
Update PropelCSVParser.php

### DIFF
--- a/runtime/lib/parser/PropelCSVParser.php
+++ b/runtime/lib/parser/PropelCSVParser.php
@@ -226,10 +226,7 @@ class PropelCSVParser extends PropelParser
 
     protected function getColumns($row)
     {
-        $delim = preg_quote($this->delimiter, '/');
-        preg_match_all('/(".+?"|[^' . $delim . ']+)(' . $delim . '|$)/', $row, $matches);
-
-        return $matches[1];
+        return str_getcsv($row, $this->delimiter);
     }
 
     /**


### PR DESCRIPTION
Regexp replaced with build in php function str_getcsv(PHP 5.3+). It allow to correct handle empty values in csv file without "N;" as value