### PR TITLE
clears instance variable 'select' in clear() method.

### DIFF
--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -984,6 +984,7 @@ class ModelCriteria extends Criteria
         $this->with = array();
         $this->primaryCriteria = null;
         $this->formatter=null;
+        $this->select=null;
 
         return $this;
     }


### PR DESCRIPTION
Not sure why this isn't done. The problem is, that I can't reuse a query object when it previously had set the select var. I couldn't find a way to clear it, so I guess this would be the place. Unless there are some underlying mechanics at work which depend on it keeping it's status. 
