### PR TITLE
Remove namespace backslash

### DIFF
--- a/generator/lib/behavior/sortable/SortableBehavior.php
+++ b/generator/lib/behavior/sortable/SortableBehavior.php
@@ -57,7 +57,7 @@ class SortableBehavior extends Behavior
         if ($this->useScope()) {
             $scopes = $this->getScopes();
             if (0 === count($scopes)) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'The sortable behavior in `%s` needs a `scope_column` parameter.',
                     $this->getTable()->getName()
                 ));


### PR DESCRIPTION
Hi,
same problem as bug #908 :
Incompatible with php 5.2
Warning: Unexpected character in input: '\' (ASCII=92)
