### PR TITLE
Fixed generating database diff

### DIFF
--- a/generator/lib/util/PropelMigrationManager.php
+++ b/generator/lib/util/PropelMigrationManager.php
@@ -60,9 +60,15 @@ class PropelMigrationManager
     {
         if (!isset($this->pdoConnections[$datasource])) {
             $buildConnection = $this->getConnection($datasource);
-            $buildConnection['dsn'] = str_replace("@DB@", $datasource, $buildConnection['dsn']);
+            $dsn = str_replace("@DB@", $datasource, $buildConnection['dsn']);
 
-            $this->pdoConnections[$datasource] = Propel::initConnection($buildConnection, $datasource);
+            // Set user + password to null if they are empty strings or missing
+            $username = isset($buildConnection['user']) && $buildConnection['user'] ? $buildConnection['user'] : null;
+            $password = isset($buildConnection['password']) && $buildConnection['password'] ? $buildConnection['password'] : null;
+
+            $pdo = new PropelPDO($dsn, $username, $password);
+            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $this->pdoConnections[$datasource] = $pdo;
         }
 
         return $this->pdoConnections[$datasource];


### PR DESCRIPTION
to use Propel::initConnection; you have to init Propel::init with a config file. Therefore other util classes are using PDO connection.

It's a fix to be able to use "propel-gen diff" with version 1.7.*

Issue #725 
