### PR TITLE
fixed phpdoc for toArray method

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -2265,7 +2265,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
         }
         $script .= "
      *
-     * @return array an associative array containing the field names (as keys) and field values
+     * @return array|string an associative array containing the field names (as keys) and field values or *RECURSION* string if object was already exported
      */
     public function toArray(\$keyType = BasePeer::$defaultKeyType, \$includeLazyLoadColumns = true, \$alreadyDumpedObjects = array()" . ($hasFks ? ", \$includeForeignObjects = false" : '') . ")
     {


### PR DESCRIPTION
this method not always returns array, in case of recursion a string \*RECURSION\* is returned and it is not described by current phpdoc.
Maybe it should return an array('\*RECURSION\*') just to be compatible, but for now just fixing phpdoc