### PR TITLE
Typo in ModelWith::init() causes joinWithI18n()-queries to flag the coll...

### DIFF
--- a/runtime/lib/formatter/ModelWith.php
+++ b/runtime/lib/formatter/ModelWith.php
@@ -51,7 +51,7 @@ class ModelWith
         $relation = $join->getRelationMap();
         $relationName = $relation->getName();
         if ($relation->getType() == RelationMap::ONE_TO_MANY) {
-            $this->isAdd = $this->isWithOneToMany = true;
+            $this->isAdd = $this->isWithOneToMany == true;
             $this->relationName = $relation->getPluralName();
             $this->relationMethod = 'add' . $relationName;
             $this->initMethod = 'init' . $this->relationName;

--- a/runtime/lib/formatter/ModelWith.php
+++ b/runtime/lib/formatter/ModelWith.php
@@ -52,6 +52,7 @@ class ModelWith
         $relationName = $relation->getName();
         if ($relation->getType() == RelationMap::ONE_TO_MANY) {
             $this->isAdd = $this->isWithOneToMany == true;
+            $this->isWithOneToMany = true;
             $this->relationName = $relation->getPluralName();
             $this->relationMethod = 'add' . $relationName;
             $this->initMethod = 'init' . $this->relationName;


### PR DESCRIPTION
...XXXI18n collection as complete, when it is not. This causes a subsequent call to getXXXI18ns() to return only the fetched translation and not all of them.