### PR TITLE
Change the default comparison for filtering to Criteria::EQUAL instead o...

### DIFF
--- a/generator/lib/builder/om/QueryBuilder.php
+++ b/generator/lib/builder/om/QueryBuilder.php
@@ -849,7 +849,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . "
 
         $script .= "
      */
-    public function filterBy$colPhpName(\$$variableName = null, \$comparison = null)
+    public function filterBy$colPhpName(\$$variableName = null, \$comparison = Criteria::EQUAL)
     {";
         if ($col->isNumericType() || $col->isTemporalType()) {
             $script .= "

--- a/runtime/lib/query/Criteria.php
+++ b/runtime/lib/query/Criteria.php
@@ -795,7 +795,7 @@ class Criteria implements IteratorAggregate
      *
      * @return Criteria A modified Criteria object.
      */
-    public function add($critOrColumn, $value = null, $comparison = null)
+    public function add($critOrColumn, $value = null, $comparison = self::EQUAL)
     {
         $criterion = $this->getCriterionForCondition($critOrColumn, $value, $comparison);
         if ($critOrColumn instanceof Criterion) {


### PR DESCRIPTION
...f null to comply to the docblock description and avoid wildcard usage to trigger unwanted Criteria::LIKE usage.