### PR TITLE
Fix removeInstanceFromPool generator for tables with dates in index

### DIFF
--- a/generator/lib/builder/om/PHP5PeerBuilder.php
+++ b/generator/lib/builder/om/PHP5PeerBuilder.php
@@ -982,7 +982,11 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
 
         $php = array();
         foreach ($pks as $pk) {
-            $php[] = '$value->get' . $pk->getPhpName() . '()';
+            if ($pk->isTemporalType()) {
+                $php[] = '$value->get' . $pk->getPhpName() . "('U')";
+            } else {
+                $php[] = '$value->get' . $pk->getPhpName() . '()';
+            }
         }
         $script .= "
                 \$key = " . $this->getInstancePoolKeySnippet($php) . ";";


### PR DESCRIPTION
Dates could not be casted to a string. The instance pool key in the addInstanceToPool is right, but at the remove there is an error.