### PR TITLE
Fix an error in the options' parser

### DIFF
--- a/runtime/lib/Propel.php
+++ b/runtime/lib/Propel.php
@@ -731,7 +731,7 @@ class Propel
             }
             $key = constant($key);
 
-            $value = $optiondata['value'];
+            $value = isset($optiondata['value']) ? $optiondata['value'] : $optiondata;
             if (is_string($value) && strpos($value, '::') !== false) {
                 if (!defined($value)) {
                     throw new PropelException("Invalid PDO option/attribute value specified: " . $value);


### PR DESCRIPTION
It hasn't worked with YML configs (at least) because a value of an option must be a scalar one