### PR TITLE
Fixed missing equal sign in Boolean comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Propel is an open-source Object-Relational Mapping (ORM) for PHP5.
 [![Build Status](https://secure.travis-ci.org/propelorm/Propel.png?branch=master)](http://travis-ci.org/propelorm/Propel)
 [![Total Downloads](https://poser.pugx.org/propel/propel1/downloads.png)](https://packagist.org/packages/propel/propel1)
 [![Latest Stable Version](https://poser.pugx.org/propel/propel1/v/stable.png)](https://packagist.org/packages/propel/propel1)
+[![Code Climate](https://codeclimate.com/github/propelorm/Propel/badges/gpa.svg)](https://codeclimate.com/github/propelorm/Propel)
 
 ## A quick tour of the features ##
 

--- a/runtime/lib/validator/MaxValueValidator.php
+++ b/runtime/lib/validator/MaxValueValidator.php
@@ -38,7 +38,7 @@ class MaxValueValidator implements BasicValidator
      */
     public function isValid(ValidatorMap $map, $value)
     {
-        if (is_null($value) == false && is_numeric($value) == true) {
+        if (is_null($value) === false && is_numeric($value) === true) {
             return intval($value) <= intval($map->getValue());
         }
 

--- a/runtime/lib/validator/MinValueValidator.php
+++ b/runtime/lib/validator/MinValueValidator.php
@@ -38,7 +38,7 @@ class MinValueValidator implements BasicValidator
      */
     public function isValid(ValidatorMap $map, $value)
     {
-        if (is_null($value) == false && is_numeric($value)) {
+        if (is_null($value) === false && is_numeric($value)) {
             return intval($value) >= intval($map->getValue());
         }
 


### PR DESCRIPTION
I ran the code through Code Climate and saw that there were three Boolean comparisons that were not using the identical operator (which is always recommended to avoid unexpected or incorrect results). I updated this to use the identical operator and added the Code Climate badge to the readme.