### PR TITLE
implements switch to abort a migration on an error

### DIFF
--- a/generator/default.properties
+++ b/generator/default.properties
@@ -207,6 +207,7 @@ propel.sql.mapper.to = *.sql
 propel.migration.editor =
 propel.migration.table = propel_migration
 propel.migration.caseInsensitive = true
+propel.migration.abortOnError = false
 
 # -------------------------------------------------------------------
 #

--- a/generator/lib/task/BasePropelMigrationTask.php
+++ b/generator/lib/task/BasePropelMigrationTask.php
@@ -94,6 +94,16 @@ abstract class BasePropelMigrationTask extends AbstractPropelTask
     }
 
     /**
+     * Decides whether to abort the migration on error or not
+     *
+     * @return bool
+     */
+    protected function abortMigrationOnError()
+    {
+        return (bool) $this->getGeneratorConfig()->getBuildProperty('migrationAbortOnError');
+    }
+
+    /**
      * Gets the GeneratorConfig object for this task or creates it on-demand.
      *
      * @return GeneratorConfig

--- a/generator/lib/task/PropelMigrationTask.php
+++ b/generator/lib/task/PropelMigrationTask.php
@@ -67,7 +67,12 @@ class PropelMigrationTask extends BasePropelMigrationTask
                         $stmt->execute();
                         $res++;
                     } catch (PDOException $e) {
-                        $this->log(sprintf('Failed to execute SQL "%s"', $statement), Project::MSG_ERR);
+                        if (true === $this->abortMigrationOnError()) {
+                            $this->log(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), Project::MSG_ERR);
+                            return false;
+                        } else {
+                            $this->log(sprintf('Failed to execute SQL "%s"', $statement), Project::MSG_ERR);
+                        }
                         // continue
                     }
                 }


### PR DESCRIPTION
I'm using the propel migration within an automated rollout process. Problem is that if within a migration file are more than 1 statement, 
```
SET FOREIGN_KEY_CHECKS = 0; 
SQL with error
SET FOREIGN_KEY_CHECKS = 1;
```

The phing tasks continues migrating. With the change i pushed you can set a configuration  flag 
```
propel.migration.abortOnError = false|true
```

if set to true the migration aborts with this task. If false it behaves as now.