### PR TITLE
Postgresql Error: DROP SEQUENCE needs IF EXISTS since PostgreSQL v8.2

### DIFF
--- a/generator/lib/platform/PgsqlPlatform.php
+++ b/generator/lib/platform/PgsqlPlatform.php
@@ -140,7 +140,7 @@ CREATE SEQUENCE %s;
     {
         if ($table->getIdMethod() == IDMethod::NATIVE && $table->getIdMethodParameters() != null) {
             $pattern = "
-DROP SEQUENCE %s;
+DROP SEQUENCE IF EXISTS %s;
 ";
 
             return sprintf($pattern,


### PR DESCRIPTION
Since Propel 8.2:

IF EXISTS

    Do not throw an error if the sequence does not exist. A notice is issued in this case.

See: https://www.postgresql.org/docs/8.2/static/sql-dropsequence.html