### PR TITLE
1.6.9 fixed for php7 by CrossKnowledge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - 7.1
 
 env:
   - DB=mysql DB_USER=root
-
-matrix:
-  allow_failures:
-    - php: 5.5
 
 before_script:
   # MySQL

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 # Propel #
 
+Propel is an open-source Object-Relational Mapping (ORM) for PHP5.
 
-**This is a fork of the outdated and unmaintained Object-Relational Mapping (ORM) [Propel 1.*](https://github.com/propelorm/Propel).**
+[![Build Status](https://secure.travis-ci.org/propelorm/Propel.png?branch=master)](http://travis-ci.org/propelorm/Propel)
+
+## A quick tour of the features ##
+
+Propel has some nice features you should know about:
+
+ - It's a fast and easy way to manage you database;
+ - It provides command line tools for generating code (well documented with an IDE-friendly syntax);
+ - It's very flexible: you can simply extend Propel;
+ - It uses PDO (PHP Data Objects) so it allows your to use the RDBMS you want (MySQL, SQLite, PostgreSQL, Oracle and MSSQL are supported);
+ - Propel is an open-source project which is [well documented](http://propelorm.org/documentation/).
+
+## Installation ##
+
+Read the [Propel documentation](http://www.propelorm.org/).
 
 
 ## License ##

--- a/README.md
+++ b/README.md
@@ -1,22 +1,7 @@
 # Propel #
 
-Propel is an open-source Object-Relational Mapping (ORM) for PHP5.
 
-[![Build Status](https://secure.travis-ci.org/propelorm/Propel.png?branch=master)](http://travis-ci.org/propelorm/Propel)
-
-## A quick tour of the features ##
-
-Propel has some nice features you should know about:
-
- - It's a fast and easy way to manage you database;
- - It provides command line tools for generating code (well documented with an IDE-friendly syntax);
- - It's very flexible: you can simply extend Propel;
- - It uses PDO (PHP Data Objects) so it allows your to use the RDBMS you want (MySQL, SQLite, PostgreSQL, Oracle and MSSQL are supported);
- - Propel is an open-source project which is [well documented](http://propelorm.org/documentation/).
-
-## Installation ##
-
-Read the [Propel documentation](http://www.propelorm.org/).
+**This is a fork of the outdated and unmaintained Object-Relational Mapping (ORM) [Propel 1.*](https://github.com/propelorm/Propel).**
 
 
 ## License ##

--- a/generator/lib/task/PropelMigrationDownTask.php
+++ b/generator/lib/task/PropelMigrationDownTask.php
@@ -50,7 +50,7 @@ class PropelMigrationDownTask extends BasePropelMigrationTask
         $migration = $manager->getMigrationObject($nextMigrationTimestamp);
         if (false === $migration->preDown($manager)) {
             $this->log(sprintf(
-                '[%s] preDown() for returned false. Aborting migration.',
+                '[%s] preDown() returned false. Aborting migration.',
                 $manager->getMigrationClassName($nextMigrationTimestamp)
             ), Project::MSG_ERR);
 

--- a/generator/lib/task/PropelMigrationDownTask.php
+++ b/generator/lib/task/PropelMigrationDownTask.php
@@ -52,7 +52,7 @@ class PropelMigrationDownTask extends BasePropelMigrationTask
             $this->log(sprintf(
                 '[%s] preDown() returned false. Aborting migration.',
                 $manager->getMigrationClassName($nextMigrationTimestamp)
-            ), Project::MSG_ERR);
+            ));
 
             return false;
         }
@@ -78,17 +78,17 @@ class PropelMigrationDownTask extends BasePropelMigrationTask
                         '[%s] Failed to execute SQL "%s"',
                         $manager->getMigrationClassName($nextMigrationTimestamp),
                         $statement
-                    ), Project::MSG_ERR);
+                    ));
                     // continue
                 }
             }
             if (!$res) {
-                $this->log('No statement was executed. The version was not updated.', Project::MSG_ERR);
+                $this->log('No statement was executed. The version was not updated.');
                 $this->log(sprintf(
                     'Please review the code in "%s"',
                     $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $manager->getMigrationClassName($nextMigrationTimestamp)
-                ), Project::MSG_ERR);
-                $this->log('Migration aborted', Project::MSG_ERR);
+                ));
+                $this->log('Migration aborted');
 
                 return false;
             }

--- a/generator/lib/task/PropelMigrationDownTask.php
+++ b/generator/lib/task/PropelMigrationDownTask.php
@@ -49,7 +49,10 @@ class PropelMigrationDownTask extends BasePropelMigrationTask
 
         $migration = $manager->getMigrationObject($nextMigrationTimestamp);
         if (false === $migration->preDown($manager)) {
-            $this->log('preDown() returned false. Aborting migration.', Project::MSG_ERR);
+            $this->log(sprintf(
+                '[%s] preDown() for returned false. Aborting migration.',
+                $manager->getMigrationClassName($nextMigrationTimestamp)
+            ), Project::MSG_ERR);
 
             return false;
         }
@@ -71,16 +74,20 @@ class PropelMigrationDownTask extends BasePropelMigrationTask
                     $stmt->execute();
                     $res++;
                 } catch (PDOException $e) {
-                    $this->log(sprintf('Failed to execute SQL "%s"', $statement), Project::MSG_ERR);
+                    $this->log(sprintf(
+                        '[%s] Failed to execute SQL "%s"',
+                        $manager->getMigrationClassName($nextMigrationTimestamp),
+                        $statement
+                    ), Project::MSG_ERR);
                     // continue
                 }
             }
             if (!$res) {
-                $this->log('No statement was executed. The version was not updated.');
+                $this->log('No statement was executed. The version was not updated.', Project::MSG_ERR);
                 $this->log(sprintf(
                     'Please review the code in "%s"',
                     $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $manager->getMigrationClassName($nextMigrationTimestamp)
-                ));
+                ), Project::MSG_ERR);
                 $this->log('Migration aborted', Project::MSG_ERR);
 
                 return false;

--- a/generator/lib/task/PropelMigrationTask.php
+++ b/generator/lib/task/PropelMigrationTask.php
@@ -47,7 +47,7 @@ class PropelMigrationTask extends BasePropelMigrationTask
             $migration = $manager->getMigrationObject($timestamp);
             if (false === $migration->preUp($manager)) {
                 $this->log(sprintf(
-                    '[%s] preUp() for returned false. Aborting migration.',
+                    '[%s] preUp() returned false. Aborting migration.',
                     $manager->getMigrationClassName($timestamp)
                 ), Project::MSG_ERR);
 

--- a/generator/lib/task/PropelMigrationTask.php
+++ b/generator/lib/task/PropelMigrationTask.php
@@ -49,7 +49,7 @@ class PropelMigrationTask extends BasePropelMigrationTask
                 $this->log(sprintf(
                     '[%s] preUp() returned false. Aborting migration.',
                     $manager->getMigrationClassName($timestamp)
-                ), Project::MSG_ERR);
+                ));
 
                 return false;
             }
@@ -74,17 +74,17 @@ class PropelMigrationTask extends BasePropelMigrationTask
                             '[%s] Failed to execute SQL "%s"',
                             $manager->getMigrationClassName($timestamp),
                             $statement
-                        ), Project::MSG_ERR);
+                        ));
                         // continue
                     }
                 }
                 if (!$res) {
-                    $this->log('No statement was executed. The version was not updated.', Project::MSG_ERR);
+                    $this->log('No statement was executed. The version was not updated.');
                     $this->log(sprintf(
                         'Please review the code in "%s"',
                         $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $manager->getMigrationClassName($timestamp)
-                    ), Project::MSG_ERR);
-                    $this->log('Migration aborted', Project::MSG_ERR);
+                    ));
+                    $this->log('Migration aborted');
 
                     return false;
                 }

--- a/generator/lib/task/PropelMigrationTask.php
+++ b/generator/lib/task/PropelMigrationTask.php
@@ -46,7 +46,10 @@ class PropelMigrationTask extends BasePropelMigrationTask
             ));
             $migration = $manager->getMigrationObject($timestamp);
             if (false === $migration->preUp($manager)) {
-                $this->log('preUp() returned false. Aborting migration.', Project::MSG_ERR);
+                $this->log(sprintf(
+                    '[%s] preUp() for returned false. Aborting migration.',
+                    $manager->getMigrationClassName($timestamp)
+                ), Project::MSG_ERR);
 
                 return false;
             }
@@ -67,16 +70,20 @@ class PropelMigrationTask extends BasePropelMigrationTask
                         $stmt->execute();
                         $res++;
                     } catch (PDOException $e) {
-                        $this->log(sprintf('Failed to execute SQL "%s"', $statement), Project::MSG_ERR);
+                        $this->log(sprintf(
+                            '[%s] Failed to execute SQL "%s"',
+                            $manager->getMigrationClassName($timestamp),
+                            $statement
+                        ), Project::MSG_ERR);
                         // continue
                     }
                 }
                 if (!$res) {
-                    $this->log('No statement was executed. The version was not updated.');
+                    $this->log('No statement was executed. The version was not updated.', Project::MSG_ERR);
                     $this->log(sprintf(
                         'Please review the code in "%s"',
                         $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $manager->getMigrationClassName($timestamp)
-                    ));
+                    ), Project::MSG_ERR);
                     $this->log('Migration aborted', Project::MSG_ERR);
 
                     return false;

--- a/generator/lib/task/PropelMigrationUpTask.php
+++ b/generator/lib/task/PropelMigrationUpTask.php
@@ -41,7 +41,10 @@ class PropelMigrationUpTask extends BasePropelMigrationTask
 
         $migration = $manager->getMigrationObject($nextMigrationTimestamp);
         if (false === $migration->preUp($manager)) {
-            $this->log('preUp() returned false. Aborting migration.', Project::MSG_ERR);
+            $this->log(sprintf(
+                '[%s] preUp() for returned false. Aborting migration.',
+                $manager->getMigrationClassName($nextMigrationTimestamp)
+            ), Project::MSG_ERR);
 
             return false;
         }
@@ -63,18 +66,22 @@ class PropelMigrationUpTask extends BasePropelMigrationTask
                     $stmt->execute();
                     $res++;
                 } catch (PDOException $e) {
-                    $this->log(sprintf('Failed to execute SQL "%s". Aborting migration.', $statement), Project::MSG_ERR);
+                    $this->log(sprintf(
+                        '[%s] Failed to execute SQL "%s"',
+                        $manager->getMigrationClassName($nextMigrationTimestamp),
+                        $statement
+                    ), Project::MSG_ERR);
 
                     return false;
                     // continue
                 }
             }
             if (!$res) {
-                $this->log('No statement was executed. The version was not updated.');
+                $this->log('No statement was executed. The version was not updated.', Project::MSG_ERR);
                 $this->log(sprintf(
                     'Please review the code in "%s"',
                     $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $manager->getMigrationClassName($nextMigrationTimestamp)
-                ));
+                ), Project::MSG_ERR);
                 $this->log('Migration aborted', Project::MSG_ERR);
 
                 return false;

--- a/generator/lib/task/PropelMigrationUpTask.php
+++ b/generator/lib/task/PropelMigrationUpTask.php
@@ -44,7 +44,7 @@ class PropelMigrationUpTask extends BasePropelMigrationTask
             $this->log(sprintf(
                 '[%s] preUp() returned false. Aborting migration.',
                 $manager->getMigrationClassName($nextMigrationTimestamp)
-            ), Project::MSG_ERR);
+            ));
 
             return false;
         }
@@ -70,19 +70,19 @@ class PropelMigrationUpTask extends BasePropelMigrationTask
                         '[%s] Failed to execute SQL "%s"',
                         $manager->getMigrationClassName($nextMigrationTimestamp),
                         $statement
-                    ), Project::MSG_ERR);
+                    ));
 
                     return false;
                     // continue
                 }
             }
             if (!$res) {
-                $this->log('No statement was executed. The version was not updated.', Project::MSG_ERR);
+                $this->log('No statement was executed. The version was not updated.');
                 $this->log(sprintf(
                     'Please review the code in "%s"',
                     $manager->getMigrationDir() . DIRECTORY_SEPARATOR . $manager->getMigrationClassName($nextMigrationTimestamp)
-                ), Project::MSG_ERR);
-                $this->log('Migration aborted', Project::MSG_ERR);
+                ));
+                $this->log('Migration aborted');
 
                 return false;
             }

--- a/generator/lib/task/PropelMigrationUpTask.php
+++ b/generator/lib/task/PropelMigrationUpTask.php
@@ -42,7 +42,7 @@ class PropelMigrationUpTask extends BasePropelMigrationTask
         $migration = $manager->getMigrationObject($nextMigrationTimestamp);
         if (false === $migration->preUp($manager)) {
             $this->log(sprintf(
-                '[%s] preUp() for returned false. Aborting migration.',
+                '[%s] preUp() returned false. Aborting migration.',
                 $manager->getMigrationClassName($nextMigrationTimestamp)
             ), Project::MSG_ERR);
 

--- a/generator/lib/util/AbstractPropelMigration.php
+++ b/generator/lib/util/AbstractPropelMigration.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Class AbstractPropelMigration
+ */
+abstract class AbstractPropelMigration implements IPropelMigration
+{
+    /**
+     * @param PropelMigrationManager $manager
+     * @return bool
+     */
+    public function preUp(PropelMigrationManager $manager)
+    {
+        return true;
+    }
+
+    /**
+     * @param PropelMigrationManager $manager
+     * @return bool
+     */
+    public function postUp(PropelMigrationManager $manager)
+    {
+        return true;
+    }
+
+    /**
+     * @param PropelMigrationManager $manager
+     * @return bool
+     */
+    public function preDown(PropelMigrationManager $manager)
+    {
+        return true;
+    }
+
+    /**
+     * @param PropelMigrationManager $manager
+     * @return bool
+     */
+    public function postDown(PropelMigrationManager $manager)
+    {
+        return true;
+    }
+}

--- a/generator/lib/util/IPropelMigration.php
+++ b/generator/lib/util/IPropelMigration.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Interface IPropelMigration
+ */
+interface IPropelMigration
+{
+    /**
+     * @param PropelMigrationManager $manager
+     * @return bool
+     */
+    public function preUp(PropelMigrationManager $manager);
+
+    /**
+     * @param PropelMigrationManager $manager
+     * @return bool
+     */
+    public function postUp(PropelMigrationManager $manager);
+
+    /**
+     * @param PropelMigrationManager $manager
+     * @return bool
+     */
+    public function preDown(PropelMigrationManager $manager);
+
+    /**
+     * @param PropelMigrationManager $manager
+     * @return bool
+     */
+    public function postDown(PropelMigrationManager $manager);
+
+    /**
+     * Get the SQL statements for the Up migration
+     *
+     * @return array list of the SQL strings to execute for the Up migration
+     *               the keys being the datasources
+     */
+    public function getUpSQL();
+
+    /**
+     * Get the SQL statements for the Down migration
+     *
+     * @return array list of the SQL strings to execute for the Down migration
+     *               the keys being the datasources
+     */
+    public function getDownSQL();
+}

--- a/generator/lib/util/PropelMigrationManager.php
+++ b/generator/lib/util/PropelMigrationManager.php
@@ -303,31 +303,10 @@ class PropelMigrationManager
 /**
  * Data object containing the SQL and PHP code to migrate the database
  * up to version $timestamp.
- * Generated on $timeInWords $migrationAuthor
+ * Auto generated on $timeInWords $migrationAuthor
  */
-class $migrationClassName
+class $migrationClassName extends AbstractPropelMigration
 {
-
-    public function preUp(\$manager)
-    {
-        // add the pre-migration code here
-    }
-
-    public function postUp(\$manager)
-    {
-        // add the post-migration code here
-    }
-
-    public function preDown(\$manager)
-    {
-        // add the pre-migration code here
-    }
-
-    public function postDown(\$manager)
-    {
-        // add the post-migration code here
-    }
-
     /**
      * Get the SQL statements for the Up migration
      *
@@ -349,7 +328,6 @@ class $migrationClassName
     {
         return $migrationDownString;
     }
-
 }
 EOP;
 

--- a/runtime/lib/adapter/DBMySQL.php
+++ b/runtime/lib/adapter/DBMySQL.php
@@ -148,6 +148,9 @@ class DBMySQL extends DBAdapter
      */
     public function applyLimit(&$sql, $offset, $limit)
     {
+        $offset = (int) $offset;
+        $limit = (int) $limit;
+
         if ($limit > 0) {
             $sql .= " LIMIT " . ($offset > 0 ? $offset . ", " : "") . $limit;
         } elseif ($offset > 0) {

--- a/runtime/lib/formatter/PropelArrayFormatter.php
+++ b/runtime/lib/formatter/PropelArrayFormatter.php
@@ -25,21 +25,23 @@ class PropelArrayFormatter extends PropelFormatter
     public function format(PDOStatement $stmt)
     {
         $this->checkInit();
-        if ($class = $this->collectionName) {
-            $collection = new $class();
-            $collection->setModel($this->class);
-            $collection->setFormatter($this);
-        } else {
-            $collection = array();
-        }
+        $collection = array();
+
         if ($this->isWithOneToMany() && $this->hasLimit) {
             throw new PropelException('Cannot use limit() in conjunction with with() on a one-to-many relationship. Please remove the with() call, or the limit() call.');
         }
         while ($row = $stmt->fetch(PDO::FETCH_NUM)) {
             if ($object = &$this->getStructuredArrayFromRow($row)) {
-                $collection[] = $object;
+                $collection[] =& $object;
             }
         }
+
+        if ($class = $this->collectionName) {
+            $collection = new $class($collection);
+            $collection->setModel($this->class);
+            $collection->setFormatter($this);
+        }
+
         $this->currentObjects = array();
         $this->alreadyHydratedObjects = array();
         $stmt->closeCursor();

--- a/runtime/lib/parser/yaml/sfYamlInline.php
+++ b/runtime/lib/parser/yaml/sfYamlInline.php
@@ -127,7 +127,7 @@ class sfYamlInline
     if (
       (1 == count($keys) && '0' == $keys[0])
       ||
-      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return (integer) $v + $w;'), 0) == count($keys) * (count($keys) - 1) / 2))
+      (count($keys) > 1 && array_reduce($keys, create_function('$v,$w', 'return (integer) $v + (integer) $w;'), 0) == count($keys) * (count($keys) - 1) / 2))
     {
       $output = array();
       foreach ($value as $val) {

--- a/runtime/lib/query/Criteria.php
+++ b/runtime/lib/query/Criteria.php
@@ -1178,8 +1178,7 @@ class Criteria implements IteratorAggregate
      */
     public function setLimit($limit)
     {
-        // TODO: do we enforce int here? 32bit issue if we do
-        $this->limit = $limit;
+        $this->limit = (int) $limit;
 
         return $this;
     }
@@ -1197,8 +1196,7 @@ class Criteria implements IteratorAggregate
     /**
      * Set offset.
      *
-     * @param int $offset An int with the value for offset.  (Note this values is
-     * 							cast to a 32bit integer and may result in truncatation)
+     * @param int $offset An int with the value for offset.
      * @return Criteria Modified Criteria object (for fluent API)
      */
     public function setOffset($offset)

--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -512,7 +512,7 @@ class ModelCriteria extends Criteria
      */
     public function select($columnArray)
     {
-        if (!count($columnArray) || $columnArray == '') {
+        if (empty($columnArray)) {
             throw new PropelException('You must ask for at least one column');
         }
 

--- a/test/testsuite/generator/behavior/AlternativeCodingStandardsBehaviorTest.php
+++ b/test/testsuite/generator/behavior/AlternativeCodingStandardsBehaviorTest.php
@@ -12,6 +12,8 @@
 require_once dirname(__FILE__) . '/../../../../generator/lib/model/Behavior.php';
 require_once dirname(__FILE__) . '/../../../../generator/lib/behavior/AlternativeCodingStandardsBehavior.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for TimestampableBehavior class
  *
@@ -19,7 +21,7 @@ require_once dirname(__FILE__) . '/../../../../generator/lib/behavior/Alternativ
  * @version    $Revision$
  * @package    generator.behavior
  */
-class AlternativeCodingStandardsBehaviorTest extends PHPUnit_Framework_TestCase
+class AlternativeCodingStandardsBehaviorTest extends TestCase
 {
     public function convertBracketsNewlineDataProvider()
     {

--- a/test/testsuite/generator/behavior/DelegateBehaviorTest.php
+++ b/test/testsuite/generator/behavior/DelegateBehaviorTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../generator/lib/util/PropelQuickBui
 require_once dirname(__FILE__) . '/../../../../generator/lib/behavior/DelegateBehavior.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for DelegateBehavior class
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior
  */
-class DelegateBehaviorTest extends PHPUnit_Framework_TestCase
+class DelegateBehaviorTest extends TestCase
 {
 
     public function setUp()

--- a/test/testsuite/generator/behavior/NamespacedBehaviorTest.php
+++ b/test/testsuite/generator/behavior/NamespacedBehaviorTest.php
@@ -1,7 +1,9 @@
 <?php
 require_once __DIR__.'/../../../fixtures/generator/behavior/Foobar.php';
 
-class NamespacedBehaviorTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class NamespacedBehaviorTest extends TestCase
 {
     /**
      * test if issue 425 is resolved

--- a/test/testsuite/generator/behavior/TableBehaviorTest.php
+++ b/test/testsuite/generator/behavior/TableBehaviorTest.php
@@ -8,13 +8,15 @@
  * @license    MIT License
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the table structure behavior hooks.
  *
  * @author     Francois Zaninotto
  * @package    generator.behavior
  */
-class TableBehaviorTest extends PHPUnit_Framework_TestCase
+class TableBehaviorTest extends TestCase
 {
     protected function setUp()
     {

--- a/test/testsuite/generator/behavior/archivable/ArchivableAndConcreteInheritanceBehaviorTest.php
+++ b/test/testsuite/generator/behavior/archivable/ArchivableAndConcreteInheritanceBehaviorTest.php
@@ -13,10 +13,12 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/archiva
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/concrete_inheritance/ConcreteInheritanceBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the combination of ArchivableBehavior and ConcreteInheritanceBehavior classes
  */
-class ArchivableAndConcreteInheritanceBehaviorTest extends PHPUnit_Framework_TestCase
+class ArchivableAndConcreteInheritanceBehaviorTest extends TestCase
 {
     protected static $generatedSQL;
 

--- a/test/testsuite/generator/behavior/archivable/ArchivableBehaviorObjectBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/archivable/ArchivableBehaviorObjectBuilderModifierTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuick
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/archivable/ArchivableBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for ArchivableBehavior class
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior.archivable
  */
-class ArchivableBehaviorObjectBuilderModifierTest extends PHPUnit_Framework_TestCase
+class ArchivableBehaviorObjectBuilderModifierTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/behavior/archivable/ArchivableBehaviorQueryBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/archivable/ArchivableBehaviorQueryBuilderModifierTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuick
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/archivable/ArchivableBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for ArchivableBehavior class
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior.archivable
  */
-class ArchivableBehaviorQueryBuilderModifierTest extends PHPUnit_Framework_TestCase
+class ArchivableBehaviorQueryBuilderModifierTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/behavior/archivable/ArchivableBehaviorTest.php
+++ b/test/testsuite/generator/behavior/archivable/ArchivableBehaviorTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuick
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/archivable/ArchivableBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for ArchivableBehavior class
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior.archivable
  */
-class ArchivableBehaviorTest extends PHPUnit_Framework_TestCase
+class ArchivableBehaviorTest extends TestCase
 {
     protected static $generatedSQL;
 

--- a/test/testsuite/generator/behavior/i18n/I18nBehaviorObjectBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/i18n/I18nBehaviorObjectBuilderModifierTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuick
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/i18n/I18nBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for I18nBehavior class object modifier
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior.i18n
  */
-class I18nBehaviorObjectBuilderModifierTest extends PHPUnit_Framework_TestCase
+class I18nBehaviorObjectBuilderModifierTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/behavior/i18n/I18nBehaviorPeerBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/i18n/I18nBehaviorPeerBuilderModifierTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuick
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/i18n/I18nBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for I18nBehavior class peer modifier
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior.i18n
  */
-class I18nBehaviorPeerBuilderModifierTest extends PHPUnit_Framework_TestCase
+class I18nBehaviorPeerBuilderModifierTest extends TestCase
 {
     public function testDefaultLocaleConstant()
     {

--- a/test/testsuite/generator/behavior/i18n/I18nBehaviorQueryBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/i18n/I18nBehaviorQueryBuilderModifierTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuick
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/i18n/I18nBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for I18nBehavior class query modifier
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior.i18n
  */
-class I18nBehaviorQueryBuilderModifierTest extends PHPUnit_Framework_TestCase
+class I18nBehaviorQueryBuilderModifierTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/behavior/i18n/I18nBehaviorTest.php
+++ b/test/testsuite/generator/behavior/i18n/I18nBehaviorTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuick
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/i18n/I18nBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for I18nBehavior class
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior.i18n
  */
-class I18nBehaviorTest extends PHPUnit_Framework_TestCase
+class I18nBehaviorTest extends TestCase
 {
     public function testModifyDatabaseOverridesDefaultLocale()
     {

--- a/test/testsuite/generator/behavior/versionable/VersionableBehaviorObjectBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/versionable/VersionableBehaviorObjectBuilderModifierTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuick
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/versionable/VersionableBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for VersionableBehavior class
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior.versionable
  */
-class VersionableBehaviorObjectBuilderModifierTest extends PHPUnit_Framework_TestCase
+class VersionableBehaviorObjectBuilderModifierTest extends TestCase
 {
 
     public function setUp()

--- a/test/testsuite/generator/behavior/versionable/VersionableBehaviorPeerBuilderModifierTest.php
+++ b/test/testsuite/generator/behavior/versionable/VersionableBehaviorPeerBuilderModifierTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuick
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/versionable/VersionableBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for VersionableBehavior class
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior.versionable
  */
-class VersionableBehaviorPeerBuilderModifierTest extends PHPUnit_Framework_TestCase
+class VersionableBehaviorPeerBuilderModifierTest extends TestCase
 {
 
     public function setUp()

--- a/test/testsuite/generator/behavior/versionable/VersionableBehaviorTest.php
+++ b/test/testsuite/generator/behavior/versionable/VersionableBehaviorTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuick
 require_once dirname(__FILE__) . '/../../../../../generator/lib/behavior/versionable/VersionableBehavior.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for VersionableBehavior class
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @version    $Revision$
  * @package    generator.behavior.versionable
  */
-class VersionableBehaviorTest extends PHPUnit_Framework_TestCase
+class VersionableBehaviorTest extends TestCase
 {
     public function basicSchemaDataProvider()
     {

--- a/test/testsuite/generator/builder/NamespaceTest.php
+++ b/test/testsuite/generator/builder/NamespaceTest.php
@@ -11,6 +11,8 @@
 require_once dirname(__FILE__) . '/../../../../runtime/lib/Propel.php';
 set_include_path(get_include_path() . PATH_SEPARATOR . realpath(dirname(__FILE__) . '/../../../fixtures/namespaced/build/classes'));
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for Namespaces in generated classes class
  * Requires a build of the 'namespaced' fixture
@@ -18,7 +20,7 @@ set_include_path(get_include_path() . PATH_SEPARATOR . realpath(dirname(__FILE__
  * @version    $Revision$
  * @package    generator.builder
  */
-class NamespaceTest extends PHPUnit_Framework_TestCase
+class NamespaceTest extends TestCase
 {
     protected function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedObjectArrayColumnTypeTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectArrayColumnTypeTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated objects for array column types accessor & mutator
  *
  * @author     Francois Zaninotto
  * @package    generator.builder.om
  */
-class GeneratedObjectArrayColumnTypeTest extends PHPUnit_Framework_TestCase
+class GeneratedObjectArrayColumnTypeTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedObjectBooleanColumnTypeTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectBooleanColumnTypeTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated objects for boolean column types accessor & mutator
  *
  * @author     Francois Zaninotto
  * @package    generator.builder.om
  */
-class GeneratedObjectBooleanColumnTypeTest extends PHPUnit_Framework_TestCase
+class GeneratedObjectBooleanColumnTypeTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedObjectDateTimeColumnTypeTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectDateTimeColumnTypeTest.php
@@ -11,6 +11,8 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated objects for temporal column types accessor & mutator.
  * This requires that the model was built with propel.useDateTimeClass=true
@@ -18,7 +20,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @author     Francois Zaninotto
  * @package    generator.builder.om
  */
-class GeneratedObjectDateTimeColumnTypeTest extends PHPUnit_Framework_TestCase
+class GeneratedObjectDateTimeColumnTypeTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedObjectEnumColumnTypeTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectEnumColumnTypeTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated objects for enum column types accessor & mutator
  *
  * @author     Francois Zaninotto
  * @package    generator.builder.om
  */
-class GeneratedObjectEnumColumnTypeTest extends PHPUnit_Framework_TestCase
+class GeneratedObjectEnumColumnTypeTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedObjectLazyLoadTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectLazyLoadTest.php
@@ -11,12 +11,14 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated Object classes for lazy load columns.
  *
  * @package    generator.builder.om
  */
-class GeneratedObjectLazyLoadTest extends PHPUnit_Framework_TestCase
+class GeneratedObjectLazyLoadTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedObjectObjectColumnTypeTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectObjectColumnTypeTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated objects for object column types accessor & mutator
  *
  * @author     Francois Zaninotto
  * @package    generator.builder.om
  */
-class GeneratedObjectObjectColumnTypeTest extends PHPUnit_Framework_TestCase
+class GeneratedObjectObjectColumnTypeTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedObjectRelTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectRelTest.php
@@ -908,7 +908,7 @@ class GeneratedObjectRelTest extends BookstoreEmptyTestBase
 
         BookPeer::clearInstancePool();
 
-        $summary = $this->getMock('BookSummary');
+        $summary = $this->createMock(BookSummary::class);
         $summary
             ->expects($this->once())
             ->method('isDeleted')

--- a/test/testsuite/generator/builder/om/GeneratedObjectTemporalColumnTypeTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectTemporalColumnTypeTest.php
@@ -11,6 +11,8 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated objects for temporal column types accessor & mutator.
  * This requires that the model was built with propel.useDateTimeClass=true
@@ -18,7 +20,7 @@ require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
  * @author     Francois Zaninotto
  * @package    generator.builder.om
  */
-class GeneratedObjectTemporalColumnTypeTest extends PHPUnit_Framework_TestCase
+class GeneratedObjectTemporalColumnTypeTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedObjectWithInterfaceTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectWithInterfaceTest.php
@@ -10,7 +10,9 @@
 
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 
-class GeneratedObjectWithInterfaceTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class GeneratedObjectWithInterfaceTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedPeerEnumColumnTypeTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedPeerEnumColumnTypeTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated Peer classes for enum column type constants
  *
  * @author     Francois Zaninotto
  * @package    generator.builder.om
  */
-class GeneratedPeerEnumColumnTypeTest extends PHPUnit_Framework_TestCase
+class GeneratedPeerEnumColumnTypeTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedPeerLazyLoadTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedPeerLazyLoadTest.php
@@ -11,12 +11,14 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated Peer classes for lazy load columns.
  *
  * @package    generator.builder.om
  */
-class GeneratedPeerLazyLoadTest extends PHPUnit_Framework_TestCase
+class GeneratedPeerLazyLoadTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedQueryArrayColumnTypeTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedQueryArrayColumnTypeTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated queries for array column types filters
  *
  * @author     Francois Zaninotto
  * @package    generator.builder.om
  */
-class GeneratedQueryArrayColumnTypeTest extends PHPUnit_Framework_TestCase
+class GeneratedQueryArrayColumnTypeTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedQueryEnumColumnTypeTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedQueryEnumColumnTypeTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated queries for enum column types filters
  *
  * @author     Francois Zaninotto
  * @package    generator.builder.om
  */
-class GeneratedQueryEnumColumnTest extends PHPUnit_Framework_TestCase
+class GeneratedQueryEnumColumnTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/builder/om/GeneratedQueryObjectColumnTypeTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedQueryObjectColumnTypeTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the generated queries for object column types filters
  *
  * @author     Francois Zaninotto
  * @package    generator.builder.om
  */
-class GeneratedQueryObjectColumnTest extends PHPUnit_Framework_TestCase
+class GeneratedQueryObjectColumnTest extends TestCase
 {
     protected $c1, $c2;
 

--- a/test/testsuite/generator/builder/om/OMBuilderNamespaceTest.php
+++ b/test/testsuite/generator/builder/om/OMBuilderNamespaceTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/model/Table.php'
 require_once dirname(__FILE__) . '/../../../../../generator/lib/builder/om/OMBuilder.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/MysqlPlatform.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test class for OMBuilder.
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/MysqlPl
  * @version    $Id: OMBuilderBuilderTest.php 1347 2009-12-03 21:06:36Z francois $
  * @package    generator.builder.om
  */
-class OMBuilderNamespaceTest extends PHPUnit_Framework_TestCase
+class OMBuilderNamespaceTest extends TestCase
 {
     public function testNoNamespace()
     {

--- a/test/testsuite/generator/builder/om/OMBuilderRelatedByTest.php
+++ b/test/testsuite/generator/builder/om/OMBuilderRelatedByTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/builder/om/OMBui
 require_once dirname(__FILE__) . '/../../../../../generator/lib/builder/util/XmlToAppData.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/DefaultPlatform.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test class for OMBuilder.
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/Default
  * @version    $Id: OMBuilderBuilderTest.php 1347 2009-12-03 21:06:36Z francois $
  * @package    generator.builder.om
  */
-class OMBuilderRelatedByTest extends PHPUnit_Framework_TestCase
+class OMBuilderRelatedByTest extends TestCase
 {
     public static $database;
 

--- a/test/testsuite/generator/builder/om/OMBuilderTest.php
+++ b/test/testsuite/generator/builder/om/OMBuilderTest.php
@@ -11,6 +11,8 @@
 require_once dirname(__FILE__) . '/../../../../tools/helpers/bookstore/BookstoreTestBase.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/builder/om/OMBuilder.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test class for OMBuilder.
  *
@@ -18,7 +20,7 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/builder/om/OMBui
  * @version    $Id: OMBuilderBuilderTest.php 1347 2009-12-03 21:06:36Z francois $
  * @package    generator.builder.om
  */
-class OMBuilderTest extends PHPUnit_Framework_TestCase
+class OMBuilderTest extends TestCase
 {
 
     public function testClear()

--- a/test/testsuite/generator/builder/om/PHP5ObjectBuilderTest.php
+++ b/test/testsuite/generator/builder/om/PHP5ObjectBuilderTest.php
@@ -14,6 +14,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/model/Table.php'
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/Column.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/ColumnDefaultValue.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test class for PHP5ObjectBuilder.
  *
@@ -21,7 +23,7 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/model/ColumnDefa
  * @version    $Id$
  * @package    generator.builder.om
  */
-class PHP5ObjectBuilderTest extends PHPUnit_Framework_TestCase
+class PHP5ObjectBuilderTest extends TestCase
 {
     protected $builder;
 

--- a/test/testsuite/generator/builder/util/DefaultEnglishPluralizerTest.php
+++ b/test/testsuite/generator/builder/util/DefaultEnglishPluralizerTest.php
@@ -10,13 +10,15 @@
 
 require_once dirname(__FILE__) . '/../../../../../generator/lib/builder/util/DefaultEnglishPluralizer.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the StandardEnglishPluralizer class
  *
  * @version    $Revision$
  * @package    generator.builder.util
  */
-class DefaultEnglishPluralizerTest extends PHPUnit_Framework_TestCase
+class DefaultEnglishPluralizerTest extends TestCase
 {
     public function getPluralFormDataProvider()
     {

--- a/test/testsuite/generator/builder/util/PropelTemplateTest.php
+++ b/test/testsuite/generator/builder/util/PropelTemplateTest.php
@@ -10,13 +10,15 @@
 
 require_once dirname(__FILE__) . '/../../../../../generator/lib/builder/util/PropelTemplate.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for PropelTemplate class
  *
  * @version    $Revision$
  * @package    generator.builder.util
  */
-class PropelTemplateTest extends PHPUnit_Framework_TestCase
+class PropelTemplateTest extends TestCase
 {
     public function testRenderStringNoParam()
     {

--- a/test/testsuite/generator/builder/util/StandardEnglishPluralizerTest.php
+++ b/test/testsuite/generator/builder/util/StandardEnglishPluralizerTest.php
@@ -10,13 +10,15 @@
 
 require_once dirname(__FILE__) . '/../../../../../generator/lib/builder/util/StandardEnglishPluralizer.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the StandardEnglishPluralizer class
  *
  * @version    $Revision$
  * @package    generator.builder.util
  */
-class StandardEnglishPluralizerTest extends PHPUnit_Framework_TestCase
+class StandardEnglishPluralizerTest extends TestCase
 {
     public function getPluralFormDataProvider()
     {

--- a/test/testsuite/generator/builder/util/XmlToAppDataTest.php
+++ b/test/testsuite/generator/builder/util/XmlToAppDataTest.php
@@ -10,13 +10,15 @@
 
 require_once dirname(__FILE__) . '/../../../../../generator/lib/builder/util/XmlToAppData.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for XmlToAppData class
  *
  * @version    $Revision$
  * @package    generator.builder.util
  */
-class XmlToAppDataTest extends PHPUnit_Framework_TestCase
+class XmlToAppDataTest extends TestCase
 {
 
     public function testParseStringEmptySchema()

--- a/test/testsuite/generator/config/GeneratorConfigTest.php
+++ b/test/testsuite/generator/config/GeneratorConfigTest.php
@@ -10,11 +10,13 @@
 
 require_once dirname(__FILE__) . '/../../../../generator/lib/config/GeneratorConfig.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author	William Durand <william.durand1@gmail.com>
  * @package	propel.generator.config
  */
-class GeneratorConfigTest extends PHPUnit_Framework_TestCase
+class GeneratorConfigTest extends TestCase
 {
     protected $pathToFixtureFiles;
 

--- a/test/testsuite/generator/model/BehaviorTest.php
+++ b/test/testsuite/generator/model/BehaviorTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../generator/lib/model/Table.php';
 require_once dirname(__FILE__) . '/../../../../generator/lib/builder/util/XmlToAppData.php';
 require_once dirname(__FILE__) . '/../../../../generator/lib/behavior/TimestampableBehavior.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for Behavior class
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../generator/lib/behavior/Timestampa
  * @version    $Revision$
  * @package    generator.model
  */
-class BehaviorTest extends PHPUnit_Framework_TestCase
+class BehaviorTest extends TestCase
 {
   private $xmlToAppData;
   private $appData;

--- a/test/testsuite/generator/model/ColumnDefaultValueTest.php
+++ b/test/testsuite/generator/model/ColumnDefaultValueTest.php
@@ -10,13 +10,15 @@
 
 require_once dirname(__FILE__) . '/../../../../generator/lib/model/ColumnDefaultValue.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for ColumnDefaultValue class.
  *
  * @version    $Revision$
  * @package    generator.model
  */
-class ColumnDefaultValueTest extends PHPUnit_Framework_TestCase
+class ColumnDefaultValueTest extends TestCase
 {
     public function equalsProvider()
     {

--- a/test/testsuite/generator/model/ColumnTest.php
+++ b/test/testsuite/generator/model/ColumnTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../generator/lib/builder/util/XmlToA
 require_once dirname(__FILE__) . '/../../../../generator/lib/platform/DefaultPlatform.php';
 require_once dirname(__FILE__) . '/../../../../generator/lib/behavior/AutoAddPkBehavior.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for package handling.
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../generator/lib/behavior/AutoAddPkB
  * @version    $Revision$
  * @package    generator.model
  */
-class ColumnTest extends PHPUnit_Framework_TestCase
+class ColumnTest extends TestCase
 {
 
     /**

--- a/test/testsuite/generator/model/DatabaseTest.php
+++ b/test/testsuite/generator/model/DatabaseTest.php
@@ -12,13 +12,15 @@
 require_once dirname(__FILE__) . '/../../../../generator/lib/model/Database.php';
 require_once dirname(__FILE__) . '/../../../tools/helpers/DummyPlatforms.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for Database model class.
  *
  * @version    $Revision$
  * @package    generator.model
  */
-class DatabaseTest extends PHPUnit_Framework_TestCase
+class DatabaseTest extends TestCase
 {
     public function providerForTestHasTable()
     {

--- a/test/testsuite/generator/model/NameFactoryTest.php
+++ b/test/testsuite/generator/model/NameFactoryTest.php
@@ -58,39 +58,6 @@ class NameFactoryTest extends BaseTestCase
     private $database;
 
     /**
-     * Creates a new instance.
-     *
-     */
-    public function __construct()
-    {
-        self::$INPUTS = array(
-                array( array(self::makeString(61), "I", 1),
-                        array(self::makeString(61), "I", 2),
-                        array(self::makeString(65), "I", 3),
-                        array(self::makeString(4), "FK", 1),
-                        array(self::makeString(5), "FK", 2)
-                    ),
-                array(
-                        array("MY_USER", NameGenerator::CONV_METHOD_UNDERSCORE),
-                        array("MY_USER", NameGenerator::CONV_METHOD_PHPNAME),
-                        array("MY_USER", NameGenerator::CONV_METHOD_NOCHANGE)
-                    )
-                );
-
-
-        self::$OUTPUTS = array(
-                        array(
-                            self::makeString(60) . "_I_1",
-                            self::makeString(60) . "_I_2",
-                            self::makeString(60) . "_I_3",
-                            self::makeString(4) . "_FK_1",
-                            self::makeString(5) . "_FK_2"),
-                        array("MyUser", "MYUSER", "MY_USER")
-                    );
-
-    }
-
-    /**
      * Creates a string of the specified length consisting entirely of
      * the character <code>A</code>.  Useful for simulating table
      * names, etc.
@@ -111,6 +78,31 @@ class NameFactoryTest extends BaseTestCase
     /** Sets up the Propel model. */
     public function setUp()
     {
+        self::$INPUTS = array(
+            array( array(self::makeString(61), "I", 1),
+                array(self::makeString(61), "I", 2),
+                array(self::makeString(65), "I", 3),
+                array(self::makeString(4), "FK", 1),
+                array(self::makeString(5), "FK", 2)
+            ),
+            array(
+                array("MY_USER", NameGenerator::CONV_METHOD_UNDERSCORE),
+                array("MY_USER", NameGenerator::CONV_METHOD_PHPNAME),
+                array("MY_USER", NameGenerator::CONV_METHOD_NOCHANGE)
+            )
+        );
+
+
+        self::$OUTPUTS = array(
+            array(
+                self::makeString(60) . "_I_1",
+                self::makeString(60) . "_I_2",
+                self::makeString(60) . "_I_3",
+                self::makeString(4) . "_FK_1",
+                self::makeString(5) . "_FK_2"),
+            array("MyUser", "MYUSER", "MY_USER")
+        );
+
         $appData = new AppData(new MysqlPlatform());
         $this->database = new Database();
         $appData->addDatabase($this->database);

--- a/test/testsuite/generator/model/PhpNameGeneratorTest.php
+++ b/test/testsuite/generator/model/PhpNameGeneratorTest.php
@@ -10,6 +10,8 @@
 
 require_once dirname(__FILE__) . '/../../../../generator/lib/model/PhpNameGenerator.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for PhpNamleGenerator
  *
@@ -17,7 +19,7 @@ require_once dirname(__FILE__) . '/../../../../generator/lib/model/PhpNameGenera
  * @version    $Revision$
  * @package    generator.model
  */
-class PhpNameGeneratorTest extends PHPUnit_Framework_TestCase
+class PhpNameGeneratorTest extends TestCase
 {
     public static function phpnameMethodDataProvider()
     {

--- a/test/testsuite/generator/model/TableTest.php
+++ b/test/testsuite/generator/model/TableTest.php
@@ -15,13 +15,15 @@ require_once dirname(__FILE__) . '/../../../../generator/lib/platform/DefaultPla
 require_once dirname(__FILE__) . '/../../../../generator/lib/platform/MysqlPlatform.php';
 require_once dirname(__FILE__) . '/../../../tools/helpers/DummyPlatforms.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for Table model class
  *
  * @author     Martin Poeschl (mpoeschl@marmot.at)
  * @package    generator.model
  */
-class TableTest extends PHPUnit_Framework_TestCase
+class TableTest extends TestCase
 {
 
     /**

--- a/test/testsuite/generator/model/XMLElementTest.php
+++ b/test/testsuite/generator/model/XMLElementTest.php
@@ -10,10 +10,12 @@
 
 require_once dirname(__FILE__) . '/../../../../generator/lib/model/XMLElement.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author William Durand <william.durand1@gmail.com>
  */
-class XMLElementTest extends PHPUnit_Framework_TestCase
+class XMLElementTest extends TestCase
 {
     /**
      * @dataProvider providerForGetDefaultValueForArray

--- a/test/testsuite/generator/model/diff/PropelColumnComparatorTest.php
+++ b/test/testsuite/generator/model/diff/PropelColumnComparatorTest.php
@@ -12,12 +12,14 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/PropelColumnComparator.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/MysqlPlatform.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the PropelColumnComparator service class.
  *
  * @package    generator.model.diff
  */
-class PropelColumnComparatorTest extends PHPUnit_Framework_TestCase
+class PropelColumnComparatorTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/model/diff/PropelDatabaseTableComparatorTest.php
+++ b/test/testsuite/generator/model/diff/PropelDatabaseTableComparatorTest.php
@@ -13,12 +13,14 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/Prope
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/PropelDatabaseDiff.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/MysqlPlatform.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the Table method of the PropelDatabaseComparator service class.
  *
  * @package    generator.model.diff
  */
-class PropelDatabaseTableComparatorTest extends PHPUnit_Framework_TestCase
+class PropelDatabaseTableComparatorTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/model/diff/PropelForeignKeyComparatorTest.php
+++ b/test/testsuite/generator/model/diff/PropelForeignKeyComparatorTest.php
@@ -11,12 +11,14 @@
 
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/PropelForeignKeyComparator.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the PropelColumnComparator service class.
  *
  * @package    generator.model.diff
  */
-class PropelForeignComparatorTest extends PHPUnit_Framework_TestCase
+class PropelForeignComparatorTest extends TestCase
 {
     public function testCompareNoDifference()
     {

--- a/test/testsuite/generator/model/diff/PropelIndexComparatorTest.php
+++ b/test/testsuite/generator/model/diff/PropelIndexComparatorTest.php
@@ -11,12 +11,14 @@
 
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/PropelIndexComparator.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the PropelColumnComparator service class.
  *
  * @package    generator.model.diff
  */
-class PropelIndexComparatorTest extends PHPUnit_Framework_TestCase
+class PropelIndexComparatorTest extends TestCase
 {
     public function testCompareNoDifference()
     {

--- a/test/testsuite/generator/model/diff/PropelTableColumnComparatorTest.php
+++ b/test/testsuite/generator/model/diff/PropelTableColumnComparatorTest.php
@@ -13,12 +13,14 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/Prope
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/PropelTableDiff.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/MysqlPlatform.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the Column methods of the PropelTableComparator service class.
  *
  * @package    generator.model.diff
  */
-class PropelTableColumnComparatorTest extends PHPUnit_Framework_TestCase
+class PropelTableColumnComparatorTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/model/diff/PropelTableForeignKeyComparatorTest.php
+++ b/test/testsuite/generator/model/diff/PropelTableForeignKeyComparatorTest.php
@@ -14,12 +14,14 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/Prope
 require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/MysqlPlatform.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/Database.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the Column methods of the PropelTableComparator service class.
  *
  * @package    generator.model.diff
  */
-class PropelTableForeignKeyComparatorTest extends PHPUnit_Framework_TestCase
+class PropelTableForeignKeyComparatorTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/model/diff/PropelTableIndexComparatorTest.php
+++ b/test/testsuite/generator/model/diff/PropelTableIndexComparatorTest.php
@@ -13,12 +13,14 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/Prope
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/PropelTableDiff.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/MysqlPlatform.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the Column methods of the PropelTableComparator service class.
  *
  * @package    generator.model.diff
  */
-class PropelTableIndexComparatorTest extends PHPUnit_Framework_TestCase
+class PropelTableIndexComparatorTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/model/diff/PropelTablePkColumnComparatorTest.php
+++ b/test/testsuite/generator/model/diff/PropelTablePkColumnComparatorTest.php
@@ -14,12 +14,14 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/Prope
 require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/MysqlPlatform.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/diff/PropelColumnComparator.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the Column methods of the PropelTableComparator service class.
  *
  * @package    generator.model.diff
  */
-class PropelTablePkColumnComparatorTest extends PHPUnit_Framework_TestCase
+class PropelTablePkColumnComparatorTest extends TestCase
 {
     public function setUp()
     {

--- a/test/testsuite/generator/platform/DefaultPlatformTest.php
+++ b/test/testsuite/generator/platform/DefaultPlatformTest.php
@@ -13,11 +13,13 @@ require_once dirname(__FILE__) . '/../../../../generator/lib/model/Column.php';
 require_once dirname(__FILE__) . '/../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  *
  * @package    generator.platform
  */
-class DefaultPlatformTest extends PHPUnit_Framework_TestCase
+class DefaultPlatformTest extends TestCase
 {
     protected $platform;
 

--- a/test/testsuite/generator/platform/PlatformTestBase.php
+++ b/test/testsuite/generator/platform/PlatformTestBase.php
@@ -10,11 +10,13 @@
 
 require_once dirname(__FILE__) . '/../../../../generator/lib/builder/util/XmlToAppData.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Base class for all Platform tests
  * @package    generator.platform
  */
-abstract class PlatformTestBase extends PHPUnit_Framework_TestCase
+abstract class PlatformTestBase extends TestCase
 {
 
     abstract protected function getPlatform();

--- a/test/testsuite/generator/reverse/mssql/MssqlSchemaParserTest.php
+++ b/test/testsuite/generator/reverse/mssql/MssqlSchemaParserTest.php
@@ -11,6 +11,8 @@
 require_once dirname(__FILE__) . '/../../../../../generator/lib/reverse/mssql/MssqlSchemaParser.php';
 require_once dirname(__FILE__) . '/../../../../../generator/lib/model/PropelTypes.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for Mssql database schema parser.
  *
@@ -18,7 +20,7 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/model/PropelType
  * @version     $Revision$
  * @package     propel.generator.reverse.mssql
  */
-class MssqlSchemaParserTest extends PHPUnit_Framework_TestCase
+class MssqlSchemaParserTest extends TestCase
 {
   public function testCleanDelimitedIdentifiers()
   {

--- a/test/testsuite/generator/reverse/mysql/MysqlSchemaParserTest.php
+++ b/test/testsuite/generator/reverse/mysql/MysqlSchemaParserTest.php
@@ -19,6 +19,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/Default
 set_include_path(get_include_path().PATH_SEPARATOR.dirname(__FILE__).'/../../../../../generator/lib');
 require_once dirname(__FILE__) . '/../../../../../generator/lib/task/PropelConvertConfTask.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for Mysql database schema parser.
  *
@@ -26,7 +28,7 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/task/PropelConve
  * @version     $Revision$
  * @package     propel.generator.reverse.mysql
  */
-class MysqlSchemaParserTest extends PHPUnit_Framework_TestCase
+class MysqlSchemaParserTest extends TestCase
 {
     protected function setUp()
     {

--- a/test/testsuite/generator/reverse/pgsql/PgsqlSchemaParserTest.php
+++ b/test/testsuite/generator/reverse/pgsql/PgsqlSchemaParserTest.php
@@ -19,6 +19,8 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/platform/Default
 set_include_path(get_include_path().PATH_SEPARATOR.dirname(__FILE__).'/../../../../../generator/lib');
 require_once dirname(__FILE__) . '/../../../../../generator/lib/task/PropelConvertConfTask.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for Pgsql database schema parser.
  *
@@ -26,7 +28,7 @@ require_once dirname(__FILE__) . '/../../../../../generator/lib/task/PropelConve
  * @version     $Revision$
  * @package     propel.generator.reverse.pgsql
  */
-class PgsqlSchemaParserTest extends PHPUnit_Framework_TestCase
+class PgsqlSchemaParserTest extends TestCase
 {
     protected function setUp()
     {

--- a/test/testsuite/generator/util/PropelDotGeneratorTest.php
+++ b/test/testsuite/generator/util/PropelDotGeneratorTest.php
@@ -11,11 +11,13 @@
 require_once dirname(__FILE__) . '/../../../../generator/lib/util/PropelDotGenerator.php';
 require_once dirname(__FILE__) . '/../../../../generator/lib/model/AppData.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  *
  * @package    generator.util
  */
-class PropelDotGeneratorTest extends PHPUnit_Framework_TestCase
+class PropelDotGeneratorTest extends TestCase
 {
     public function testEmptyDatabase()
     {

--- a/test/testsuite/generator/util/PropelPHPParserTest.php
+++ b/test/testsuite/generator/util/PropelPHPParserTest.php
@@ -10,11 +10,13 @@
 
 require_once dirname(__FILE__) . '/../../../../generator/lib/util/PropelPHPParser.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  *
  * @package    generator.util
  */
-class PropelPHPParserTest extends PHPUnit_Framework_TestCase
+class PropelPHPParserTest extends TestCase
 {
     public function basicClassCodeProvider()
     {

--- a/test/testsuite/generator/util/PropelQuickBuilderTest.php
+++ b/test/testsuite/generator/util/PropelQuickBuilderTest.php
@@ -11,11 +11,13 @@
 require_once dirname(__FILE__) . '/../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  *
  * @package    generator.util
  */
-class PropelQuickBuilderTest extends PHPUnit_Framework_TestCase
+class PropelQuickBuilderTest extends TestCase
 {
     public function testGetPlatform()
     {

--- a/test/testsuite/generator/util/PropelSQLParserTest.php
+++ b/test/testsuite/generator/util/PropelSQLParserTest.php
@@ -10,11 +10,13 @@
 
 require_once dirname(__FILE__) . '/../../../../generator/lib/util/PropelSQLParser.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  *
  * @package    generator.util
  */
-class PropelSQLParserTest extends PHPUnit_Framework_TestCase
+class PropelSQLParserTest extends TestCase
 {
     public function stripSqlCommentsDataProvider()
     {

--- a/test/testsuite/generator/util/PropelSchemaValidatorTest.php
+++ b/test/testsuite/generator/util/PropelSchemaValidatorTest.php
@@ -12,11 +12,13 @@ require_once dirname(__FILE__) . '/../../../../generator/lib/util/PropelSchemaVa
 require_once dirname(__FILE__) . '/../../../../generator/lib/util/PropelQuickBuilder.php';
 require_once dirname(__FILE__) . '/../../../../generator/lib/model/AppData.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  *
  * @package    generator.util
  */
-class SchemaValidatorTest extends PHPUnit_Framework_TestCase
+class SchemaValidatorTest extends TestCase
 {
 
     private $xsdFile = 'generator/resources/xsd/database.xsd';

--- a/test/testsuite/misc/FieldnameRelatedTest.php
+++ b/test/testsuite/misc/FieldnameRelatedTest.php
@@ -8,6 +8,8 @@
  * @license    MIT License
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests some of the methods of generated Object classes. These are:
  *
@@ -27,7 +29,7 @@
  * @author     Sven Fuchs <svenfuchs@artweb-design.de>
  * @package    misc
  */
-class FieldnameRelatedTest extends PHPUnit_Framework_TestCase
+class FieldnameRelatedTest extends TestCase
 {
     protected function setUp()
     {

--- a/test/testsuite/runtime/adapter/DBMySQLTest.php
+++ b/test/testsuite/runtime/adapter/DBMySQLTest.php
@@ -98,6 +98,194 @@ class DBMySQLTest extends BookstoreTestBase
 
         return $con;
     }
+
+    /**
+     * @dataProvider dataApplyLimit
+     */
+    public function testApplyLimit($offset, $limit, $expectedSql)
+    {
+        $sql = '';
+
+        $db = new DBMySQL();
+        $db->applyLimit($sql, $offset, $limit);
+
+        $this->assertEquals($expectedSql, $sql, 'Generated SQL does not match expected SQL');
+    }
+
+    public function dataApplyLimit()
+    {
+        return array(
+
+            /*
+                Offset & limit = 0
+             */
+
+            'Zero offset & limit' => array(
+                'offset'      => 0,
+                'limit'       => 0,
+                'expectedSql' => ''
+            ),
+
+            /*
+                Offset = 0
+             */
+
+            '32-bit limit' => array(
+                'offset'      => 0,
+                'limit'       => 4294967295,
+                'expectedSql' => ' LIMIT 4294967295'
+            ),
+            '32-bit limit as a string' => array(
+                'offset'      => 0,
+                'limit'       => '4294967295',
+                'expectedSql' => ' LIMIT 4294967295'
+            ),
+
+            '64-bit limit' => array(
+                'offset'      => 0,
+                'limit'       => 9223372036854775807,
+                'expectedSql' => ' LIMIT 9223372036854775807'
+            ),
+            '64-bit limit as a string' => array(
+                'offset'      => 0,
+                'limit'       => '9223372036854775807',
+                'expectedSql' => ' LIMIT 9223372036854775807'
+            ),
+
+            'Float limit' => array(
+                'offset'      => 0,
+                'limit'       => 123.9,
+                'expectedSql' => ' LIMIT 123'
+            ),
+            'Float limit as a string' => array(
+                'offset'      => 0,
+                'limit'       => '123.9',
+                'expectedSql' => ' LIMIT 123'
+            ),
+
+            'Negative limit' => array(
+                'offset'      => 0,
+                'limit'       => -1,
+                'expectedSql' => ''
+            ),
+            'Non-numeric string limit' => array(
+                'offset'      => 0,
+                'limit'       => 'foo',
+                'expectedSql' => ''
+            ),
+            'SQL injected limit' => array(
+                'offset'      => 0,
+                'limit'       => '3;DROP TABLE abc',
+                'expectedSql' => ' LIMIT 3'
+            ),
+
+            /*
+                Limit = 0
+             */
+
+            '32-bit offset' => array(
+                'offset'      => 4294967295,
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 4294967295, 18446744073709551615'
+            ),
+            '32-bit offset as a string' => array(
+                'offset'      => '4294967295',
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 4294967295, 18446744073709551615'
+            ),
+
+            '64-bit offset' => array(
+                'offset'      => 9223372036854775807,
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 9223372036854775807, 18446744073709551615'
+            ),
+            '64-bit offset as a string' => array(
+                'offset'      => '9223372036854775807',
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 9223372036854775807, 18446744073709551615'
+            ),
+
+            'Float offset' => array(
+                'offset'      => 123.9,
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 123, 18446744073709551615'
+            ),
+            'Float offset as a string' => array(
+                'offset'      => '123.9',
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 123, 18446744073709551615'
+            ),
+
+            'Negative offset' => array(
+                'offset'      => -1,
+                'limit'       => 0,
+                'expectedSql' => ''
+            ),
+            'Non-numeric string offset' => array(
+                'offset'      => 'foo',
+                'limit'       => 0,
+                'expectedSql' => ''
+            ),
+            'SQL injected offset' => array(
+                'offset'      => '3;DROP TABLE abc',
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 3, 18446744073709551615'
+            ),
+
+            /*
+                Offset & limit != 0
+             */
+
+            array(
+                'offset'      => 4294967295,
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 4294967295, 999'
+            ),
+            array(
+                'offset'      => '4294967295',
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 4294967295, 999'
+            ),
+
+            array(
+                'offset'      => 9223372036854775807,
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 9223372036854775807, 999'
+            ),
+            array(
+                'offset'      => '9223372036854775807',
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 9223372036854775807, 999'
+            ),
+
+            array(
+                'offset'      => 123.9,
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 123, 999'
+            ),
+            array(
+                'offset'      => '123.9',
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 123, 999'
+            ),
+
+            array(
+                'offset'      => -1,
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 999'
+            ),
+            array(
+                'offset'      => 'foo',
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 999'
+            ),
+            array(
+                'offset'      => '3;DROP TABLE abc',
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 3, 999'
+            ),
+        );
+    }
 }
 
 // See: http://stackoverflow.com/questions/3138946/mocking-the-pdo-object-using-phpunit

--- a/test/testsuite/runtime/adapter/DBPostgresTest.php
+++ b/test/testsuite/runtime/adapter/DBPostgresTest.php
@@ -11,6 +11,8 @@
 require_once dirname(__FILE__) . '/../../../../runtime/lib/adapter/DBAdapter.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/adapter/DBPostgres.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the DbPostgres adapter
  *
@@ -18,7 +20,7 @@ require_once dirname(__FILE__) . '/../../../../runtime/lib/adapter/DBPostgres.ph
  * @author     Kévin Gomez <contact@kevingomez.fr<
  * @package    runtime.adapter
  */
-class DBPostgresTest extends PHPUnit_Framework_TestCase
+class DBPostgresTest extends TestCase
 {
   public function testGetExplainPlanQuery()
   {

--- a/test/testsuite/runtime/config/PropelConfigurationTest.php
+++ b/test/testsuite/runtime/config/PropelConfigurationTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../runtime/lib/config/PropelConfiguration.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/config/PropelConfigurationIterator.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for PropelConfiguration class
  *
  * @author     Francois Zaninotto
  * @package    runtime.config
  */
-class PropelConfigurationTest extends PHPUnit_Framework_TestCase
+class PropelConfigurationTest extends TestCase
 {
     public static function configurationProvider()
     {

--- a/test/testsuite/runtime/connection/PropelPDOTest.php
+++ b/test/testsuite/runtime/connection/PropelPDOTest.php
@@ -10,12 +10,14 @@
 
 require_once dirname(__FILE__) . '/../../../tools/helpers/bookstore/BookstoreTestBase.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for PropelPDO subclass.
  *
  * @package    runtime.connection
  */
-class PropelPDOTest extends PHPUnit_Framework_TestCase
+class PropelPDOTest extends TestCase
 {
 
     public function testSetAttribute()

--- a/test/testsuite/runtime/exception/PropelExceptionTest.php
+++ b/test/testsuite/runtime/exception/PropelExceptionTest.php
@@ -10,13 +10,15 @@
 
 require_once dirname(__FILE__) . '/../../../../runtime/lib/exception/PropelException.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for PropelException class
  *
  * @author     Francois Zaninotto
  * @package    runtime.exception
  */
-class PropelExceptionTest extends PHPUnit_Framework_TestCase
+class PropelExceptionTest extends TestCase
 {
     public function testSimpleConstructor()
     {

--- a/test/testsuite/runtime/map/RelationMapTest.php
+++ b/test/testsuite/runtime/map/RelationMapTest.php
@@ -13,6 +13,8 @@ require_once dirname(__FILE__) . '/../../../../runtime/lib/map/RelationMap.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/map/ColumnMap.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/map/TableMap.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test class for RelationMap.
  *
@@ -20,7 +22,7 @@ require_once dirname(__FILE__) . '/../../../../runtime/lib/map/TableMap.php';
  * @version    $Id$
  * @package    runtime.map
  */
-class RelationMapTest extends PHPUnit_Framework_TestCase
+class RelationMapTest extends TestCase
 {
   protected $databaseMap, $relationName, $rmap;
 

--- a/test/testsuite/runtime/map/TableMapTest.php
+++ b/test/testsuite/runtime/map/TableMapTest.php
@@ -14,6 +14,8 @@ require_once dirname(__FILE__) . '/../../../../runtime/lib/map/TableMap.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/map/DatabaseMap.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/exception/PropelException.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test class for TableMap.
  *
@@ -21,7 +23,7 @@ require_once dirname(__FILE__) . '/../../../../runtime/lib/exception/PropelExcep
  * @version    $Id$
  * @package    runtime.map
  */
-class TableMapTest extends PHPUnit_Framework_TestCase
+class TableMapTest extends TestCase
 {
   protected $databaseMap;
 

--- a/test/testsuite/runtime/om/BaseObjectTest.php
+++ b/test/testsuite/runtime/om/BaseObjectTest.php
@@ -10,6 +10,8 @@
 
 require_once dirname(__FILE__) . '/../../../../runtime/lib/om/BaseObject.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test class for BaseObject.
  *
@@ -17,7 +19,7 @@ require_once dirname(__FILE__) . '/../../../../runtime/lib/om/BaseObject.php';
  * @version    $Id: BaseObjectTest.php 1347 2009-12-03 21:06:36Z francois $
  * @package    runtime.om
  */
-class BaseObjectTest extends PHPUnit_Framework_TestCase
+class BaseObjectTest extends TestCase
 {
     public function testGetVirtualColumns()
     {

--- a/test/testsuite/runtime/parser/PropelCSVParserTest.php
+++ b/test/testsuite/runtime/parser/PropelCSVParserTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../runtime/lib/parser/PropelParser.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/parser/PropelCSVParser.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for PropelCSVParser class
  *
  * @author     Francois Zaninotto
  * @package    runtime.parser
  */
-class PropelCSVParserTest extends PHPUnit_Framework_TestCase
+class PropelCSVParserTest extends TestCase
 {
     public static function arrayCsvConversionDataProvider()
     {

--- a/test/testsuite/runtime/parser/PropelJSONParserTest.php
+++ b/test/testsuite/runtime/parser/PropelJSONParserTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../runtime/lib/parser/PropelParser.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/parser/PropelJSONParser.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for PropelJSONParser class
  *
  * @author     Francois Zaninotto
  * @package    runtime.parser
  */
-class PropelJSONParserTest extends PHPUnit_Framework_TestCase
+class PropelJSONParserTest extends TestCase
 {
     public static function arrayJsonConversionDataProvider()
     {

--- a/test/testsuite/runtime/parser/PropelParserTest.php
+++ b/test/testsuite/runtime/parser/PropelParserTest.php
@@ -12,13 +12,15 @@ require_once dirname(__FILE__) . '/../../../../runtime/lib/parser/PropelParser.p
 require_once dirname(__FILE__) . '/../../../../runtime/lib/parser/PropelXMLParser.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/exception/PropelException.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for PropelJSONParser class
  *
  * @author     Francois Zaninotto
  * @package    runtime.parser
  */
-class PropelParserTest extends PHPUnit_Framework_TestCase
+class PropelParserTest extends TestCase
 {
     public function testGetParser()
     {

--- a/test/testsuite/runtime/parser/PropelXMLParserTest.php
+++ b/test/testsuite/runtime/parser/PropelXMLParserTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../runtime/lib/parser/PropelParser.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/parser/PropelXMLParser.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for PropelXMLParser class
  *
  * @author     Francois Zaninotto
  * @package    runtime.parser
  */
-class PropelXMLParserTest extends PHPUnit_Framework_TestCase
+class PropelXMLParserTest extends TestCase
 {
     public static function arrayXmlConversionDataProvider()
     {

--- a/test/testsuite/runtime/parser/PropelYAMLParserTest.php
+++ b/test/testsuite/runtime/parser/PropelYAMLParserTest.php
@@ -11,13 +11,15 @@
 require_once dirname(__FILE__) . '/../../../../runtime/lib/parser/PropelParser.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/parser/PropelYAMLParser.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for PropelYAMLParser class
  *
  * @author     Francois Zaninotto
  * @package    runtime.parser
  */
-class PropelYAMLParserTest extends PHPUnit_Framework_TestCase
+class PropelYAMLParserTest extends TestCase
 {
     public static function arrayYAMLConversionDataProvider()
     {

--- a/test/testsuite/runtime/query/CriteriaTest.php
+++ b/test/testsuite/runtime/query/CriteriaTest.php
@@ -1102,14 +1102,158 @@ class CriteriaTest extends BookstoreTestBase
         $this->assertFalse($c->getUseTransaction(), 'useTransaction is false by default');
     }
 
-    public function testLimit()
+    public function testDefaultLimit()
     {
         $c = new Criteria();
         $this->assertEquals(0, $c->getLimit(), 'Limit is 0 by default');
+    }
 
-        $c2 = $c->setLimit(1);
-        $this->assertEquals(1, $c->getLimit(), 'Limit is set by setLimit');
+    /**
+     * @dataProvider dataLimit
+     */
+    public function testLimit($limit, $expected)
+    {
+        $c = new Criteria();
+        $c2 = $c->setLimit($limit);
+
+        $this->assertSame($expected, $c->getLimit(), 'Correct limit is set by setLimit()');
         $this->assertSame($c, $c2, 'setLimit() returns the current Criteria');
+    }
+
+    public function dataLimit()
+    {
+        return array(
+            'Negative value' => array(
+                'limit'    => -1,
+                'expected' => -1
+            ),
+            'Zero' => array(
+                'limit'    => 0,
+                'expected' => 0
+            ),
+
+            'Small integer' => array(
+                'limit'    => 38427,
+                'expected' => 38427
+            ),
+            'Small integer as a string' => array(
+                'limit'    => '38427',
+                'expected' => 38427
+            ),
+
+            'Largest 32-bit integer' => array(
+                'limit'    => 2147483647,
+                'expected' => 2147483647
+            ),
+            'Largest 32-bit integer as a string' => array(
+                'limit'    => '2147483647',
+                'expected' => 2147483647
+            ),
+
+            'Largest 64-bit integer' => array(
+                'limit'    => 9223372036854775807,
+                'expected' => 9223372036854775807
+            ),
+            'Largest 64-bit integer as a string' => array(
+                'limit'    => '9223372036854775807',
+                'expected' => 9223372036854775807
+            ),
+
+            'Decimal value' => array(
+                'limit'    => 123.9,
+                'expected' => 123
+            ),
+            'Decimal value as a string' => array(
+                'limit'    => '123.9',
+                'expected' => 123
+            ),
+
+            'Non-numeric string' => array(
+                'limit'    => 'foo',
+                'expected' => 0
+            ),
+            'Injected SQL' => array(
+                'limit'    => '3;DROP TABLE abc',
+                'expected' => 3
+            ),
+        );
+    }
+
+    public function testDefaultOffset()
+    {
+        $c = new Criteria();
+        $this->assertEquals(0, $c->getOffset(), 'Offset is 0 by default');
+    }
+
+    /**
+     * @dataProvider dataOffset
+     */
+    public function testOffset($offset, $expected)
+    {
+        $c = new Criteria();
+        $c2 = $c->setOffset($offset);
+
+        $this->assertSame($expected, $c->getOffset(), 'Correct offset is set by setOffset()');
+        $this->assertSame($c, $c2, 'setOffset() returns the current Criteria');
+    }
+
+    public function dataOffset()
+    {
+        return array(
+            'Negative value' => array(
+                'offset'   => -1,
+                'expected' => -1
+            ),
+            'Zero' => array(
+                'offset'   => 0,
+                'expected' => 0
+            ),
+
+            'Small integer' => array(
+                'offset'   => 38427,
+                'expected' => 38427
+            ),
+            'Small integer as a string' => array(
+                'offset'   => '38427',
+                'expected' => 38427
+            ),
+
+            'Largest 32-bit integer' => array(
+                'offset'   => 2147483647,
+                'expected' => 2147483647
+            ),
+            'Largest 32-bit integer as a string' => array(
+                'offset'   => '2147483647',
+                'expected' => 2147483647
+            ),
+
+            'Largest 64-bit integer' => array(
+                'offset'   => 9223372036854775807,
+                'expected' => 9223372036854775807
+            ),
+            'Largest 64-bit integer as a string' => array(
+                'offset'   => '9223372036854775807',
+                'expected' => 9223372036854775807
+            ),
+
+            'Decimal value' => array(
+                'offset'   => 123.9,
+                'expected' => 123
+            ),
+            'Decimal value as a string' => array(
+                'offset'   => '123.9',
+                'expected' => 123
+            ),
+
+            'Non-numeric string' => array(
+                'offset'   => 'foo',
+                'expected' => 0
+            ),
+            'Injected SQL' => array(
+                'offset'   => '3;DROP TABLE abc',
+                'expected' => 3
+            ),
+        );
     }
 
     public function testDistinct()

--- a/test/testsuite/runtime/util/PropelDateTimeTest.php
+++ b/test/testsuite/runtime/util/PropelDateTimeTest.php
@@ -11,6 +11,8 @@
 require_once dirname(__FILE__) . '/../../../../runtime/lib/util/PropelDateTime.php';
 require_once dirname(__FILE__) . '/../../../../runtime/lib/exception/PropelException.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for DateTime subclass to support serialization.
  *
@@ -18,7 +20,7 @@ require_once dirname(__FILE__) . '/../../../../runtime/lib/exception/PropelExcep
  * @author		 Soenke Ruempler
  * @package		runtime.util
  */
-class PropelDateTimeTest extends PHPUnit_Framework_TestCase
+class PropelDateTimeTest extends TestCase
 {
 
     /**

--- a/test/tools/helpers/BaseTestCase.php
+++ b/test/tools/helpers/BaseTestCase.php
@@ -10,6 +10,8 @@
 
 require_once dirname(__FILE__) . '/../../../runtime/lib/Propel.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Base functionality to be extended by all Propel test cases.  Test
  * case implementations are used to automate unit testing via PHPUnit.
@@ -19,7 +21,7 @@ require_once dirname(__FILE__) . '/../../../runtime/lib/Propel.php';
  * @author     Christopher Elkins <celkins@scardini.com> (Torque)
  * @version    $Revision$
  */
-abstract class BaseTestCase extends PHPUnit_Framework_TestCase
+abstract class BaseTestCase extends TestCase
 {
     /**
      * Conditional compilation flag.

--- a/test/tools/helpers/PlatformDatabaseBuildTimeBase.php
+++ b/test/tools/helpers/PlatformDatabaseBuildTimeBase.php
@@ -1,6 +1,8 @@
 <?php
 
-class PlatformDatabaseBuildTimeBase extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PlatformDatabaseBuildTimeBase extends TestCase
 {
 
     /**

--- a/test/tools/helpers/bookstore/BookstoreTestBase.php
+++ b/test/tools/helpers/bookstore/BookstoreTestBase.php
@@ -12,10 +12,12 @@ require_once dirname(__FILE__) . '/../../../../runtime/lib/Propel.php';
 set_include_path(get_include_path() . PATH_SEPARATOR . realpath(dirname(__FILE__) . '/../../../fixtures/bookstore/build/classes'));
 Propel::init(dirname(__FILE__) . '/../../../fixtures/bookstore/build/conf/bookstore-conf.php');
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Base class contains some methods shared by subclass test cases.
  */
-abstract class BookstoreTestBase extends PHPUnit_Framework_TestCase
+abstract class BookstoreTestBase extends TestCase
 {
     protected $con;
 

--- a/test/tools/helpers/cms/CmsTestBase.php
+++ b/test/tools/helpers/cms/CmsTestBase.php
@@ -13,10 +13,12 @@ set_include_path(get_include_path() . PATH_SEPARATOR . realpath(dirname(__FILE__
 Propel::init(dirname(__FILE__) . '/../../../fixtures/bookstore/build/conf/bookstore-conf.php');
 include_once dirname(__FILE__) . '/CmsDataPopulator.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Base class contains some methods shared by subclass test cases.
  */
-abstract class CmsTestBase extends PHPUnit_Framework_TestCase
+abstract class CmsTestBase extends TestCase
 {
     protected $con;
 

--- a/test/tools/helpers/namespaces/NamespacesTestBase.php
+++ b/test/tools/helpers/namespaces/NamespacesTestBase.php
@@ -11,10 +11,12 @@
 require_once dirname(__FILE__) . '/../../../../runtime/lib/Propel.php';
 set_include_path(get_include_path() . PATH_SEPARATOR . realpath(dirname(__FILE__) . '/../../../fixtures/namespaced/build/classes'));
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Bse class for tests on the schemas schema
  */
-abstract class NamespacesTestBase extends PHPUnit_Framework_TestCase
+abstract class NamespacesTestBase extends TestCase
 {
 
     protected function setUp()

--- a/test/tools/helpers/schemas/SchemasTestBase.php
+++ b/test/tools/helpers/schemas/SchemasTestBase.php
@@ -11,10 +11,12 @@
 require_once dirname(__FILE__) . '/../../../../runtime/lib/Propel.php';
 set_include_path(get_include_path() . PATH_SEPARATOR . realpath(dirname(__FILE__) . '/../../../fixtures/schemas/build/classes'));
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Bse class for tests on the schemas schema
  */
-abstract class SchemasTestBase extends PHPUnit_Framework_TestCase
+abstract class SchemasTestBase extends TestCase
 {
 
     protected function setUp()


### PR DESCRIPTION
**This merge request contains Propel version 1.6.9 corrected to work with PHP 7.1**

The tests have also been corrected.
You can find the _green_ Travis CI status here: https://travis-ci.org/CrossKnowledge/Propel#2

Regards,
Jean-Michael