### PR TITLE
Fix - i18n Behavior locale column limitation

### DIFF
--- a/generator/lib/behavior/i18n/I18nBehavior.php
+++ b/generator/lib/behavior/i18n/I18nBehavior.php
@@ -128,7 +128,7 @@ class I18nBehavior extends Behavior
             $this->i18nTable->addColumn(array(
                 'name'       => $localeColumnName,
                 'type'       => PropelTypes::VARCHAR,
-                'size'       => 5,
+                'size'       => 255,
                 'default'    => $this->getDefaultLocale(),
                 'primaryKey' => 'true',
             ));


### PR DESCRIPTION
Don't limit locale column size to 5 chars.

Sometimes culture codes can be longer.
Example: `zh_Hant` -- Chinese Traditional.
Storage-wise there's no difference between VARCHAR(255) and VARCHAR(5)