### PR TITLE
Workaround for php72 on 1 6 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "propel/propel1",
+  "name": "propel/propel1sf",
   "description": "Propel is an open-source Object-Relational Mapping (ORM) for PHP5.",
   "keywords": ["ORM"],
   "homepage": "http://www.propelorm.org/",

--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -150,6 +150,15 @@ class PHP5ObjectBuilder extends ObjectBuilder
 		} else if ($col->isPhpPrimitiveType()) {
 			settype($val, $col->getPhpType());
 			$defaultValue = var_export($val, true);
+            /*
+             * Workaround for changes in var_export functioning in php 7.x when generating for 5.x
+             * If the default string is "0" but the type is double, then the output would be 0.0
+             * FIXME: Might have to revert this back to original state when using the result in 7.x
+             */
+            if ($defaultValue !== $val && $col->getPhpType() == 'double') {
+                settype($val, "int");
+                $defaultValue = var_export($val, true);
+            }
 		} elseif ($col->isPhpObjectType()) {
 			$defaultValue = 'new '.$col->getPhpType().'(' . var_export($val, true) . ')';
 		} else {


### PR DESCRIPTION
@jacovdloo Here is the change I needed to get php72 to generate php55 compatible code. We may have to revisit but it gives an idea of what changed in the generation code when run with php7.2