### PR TITLE
Fix voor VersionableBehavior met afwijkende kolomnamen

### DIFF
--- a/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -468,7 +468,7 @@ public function populateFromVersion(\$version, \$con = null, &\$loadedObjects = 
             $foreignBehavior = $foreignTable->getBehavior($this->behavior->getName());
             $foreignVersionTable = $foreignBehavior->getVersionTable();
             $fkColumn = $foreignVersionTable->getFirstPrimaryKeyColumn();
-            $fkVersionColumn = $foreignVersionTable->getColumn($this->behavior->getParameter('version_column'));
+            $fkVersionColumn = $foreignVersionTable->getColumn(foreignBehavior->getParameter('version_column'));
 
             $relatedClassname = $this->builder->getNewStubObjectBuilder($foreignTable)->getClassname();
 


### PR DESCRIPTION
Wanneer twee gerelateerde tabellen allebei versionable zijn en verschillende afwijkende veldnamen hebben voor het version-veld, ging het stuk