### PR TITLE
pin CI's dist to run PHP 5.4 and 5.5 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 
 branches:
   only:


### PR DESCRIPTION
@staabm [CI failed](https://travis-ci.org/propelorm/Propel/builds/607323989) for the [recent security fix](https://github.com/propelorm/Propel/pull/1054) by @mpetrovich.
This pins [Travis's dist](https://docs.travis-ci.com/user/languages/php/#php-54x---55x-support-is-available-on-precise-and-trusty-only) to Ubuntu Trusty (14.04) so tests run (and pass).