### PR TITLE
Correct deprecated methods in PHP7.4 (#1079)

### DIFF
--- a/runtime/lib/query/Join.php
+++ b/runtime/lib/query/Join.php
@@ -537,7 +537,7 @@ class Join
             for ($i = 0; $i < $this->count; $i++) {
                 $conditions [] = $this->getLeftColumn($i) . $this->getOperator($i) . $this->getRightColumn($i);
             }
-            $joinCondition = sprintf('(%s)', implode($conditions, ' AND '));
+            $joinCondition = sprintf('(%s)', implode(' AND ', $conditions));
         } else {
             $joinCondition = '';
             $this->getJoinCondition()->appendPsTo($joinCondition, $params);

--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -525,7 +525,7 @@ class ModelCriteria extends Criteria
      */
     public function select($columnArray)
     {
-        if (!count($columnArray) || $columnArray == '') {
+        if (empty($columnArray)) {
             throw new PropelException('You must ask for at least one column');
         }
 


### PR DESCRIPTION
* `runtime/lib/query/Join.php`
  `implode()` was used against the definition (wrong PHP documentation

* `runtime/lib/query/ModelCriteria.php`
  `count()` was used on non-countable variable (non-array)