### PR TITLE
Fixed deprecated curley bracket array access for Php 7.4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE test; CREATE SCHEMA bookstore_schemas; CREATE SCHEMA contest; CREATE SCHEMA second_hand_books; CREATE DATABASE reverse_bookstore;'; fi"
 
   # Composer
-  - wget http://getcomposer.org/composer.phar
+  - wget https://getcomposer.org/download/1.8.6/composer.phar
   - php composer.phar install --prefer-source
 
   - ./test/reset_tests.sh

--- a/generator/lib/config/GeneratorConfig.php
+++ b/generator/lib/config/GeneratorConfig.php
@@ -121,7 +121,7 @@ class GeneratorConfig implements GeneratorConfigInterface
         // Basically, we want to turn ?.?.?.sqliteDataSQLBuilder into ?.?.?.SqliteDataSQLBuilder
         $lastdotpos = strrpos($classpath, '.');
         if ($lastdotpos !== false) {
-            $classpath{$lastdotpos + 1} = strtoupper($classpath{$lastdotpos + 1});
+            $classpath[$lastdotpos + 1] = strtoupper($classpath[$lastdotpos + 1]);
         } else {
             // Allows to configure full classname instead of a dot-path notation
             if (class_exists($classpath)) {

--- a/generator/lib/config/QuickGeneratorConfig.php
+++ b/generator/lib/config/QuickGeneratorConfig.php
@@ -62,7 +62,7 @@ class QuickGeneratorConfig implements GeneratorConfigInterface
         }
         foreach ($lines as $line) {
             $line = trim($line);
-            if ($line == "" || $line{0} == '#' || $line{0} == ';') {
+            if ($line == "" || $line[0] == '#' || $line[0] == ';') {
                 continue;
             }
             $pos = strpos($line, '=');

--- a/runtime/lib/util/BasePeer.php
+++ b/runtime/lib/util/BasePeer.php
@@ -397,10 +397,10 @@ class BasePeer
                                 $rawcvt = '';
                                 // parse the $params['raw'] for ? chars
                                 for ($r = 0, $len = strlen($raw); $r < $len; $r++) {
-                                    if ($raw{$r} == '?') {
+                                    if ($raw[$r] == '?') {
                                         $rawcvt .= ':p' . $p++;
                                     } else {
-                                        $rawcvt .= $raw{$r};
+                                        $rawcvt .= $raw[$r];
                                     }
                                 }
                                 $sql .= $rawcvt . ', ';


### PR DESCRIPTION
This is an attempt to satisfy the request for additional changes requested so that #1080 could be merged.

I have not tested it but considering as far as I can tell all that is required is the substitution of { } curly braces for [ ] brackets it should be pretty straightforward.