### PR TITLE
Have travis CI use older version of composer to avoid case issues with pear package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE test; CREATE SCHEMA bookstore_schemas; CREATE SCHEMA contest; CREATE SCHEMA second_hand_books; CREATE DATABASE reverse_bookstore;'; fi"
 
   # Composer
-  - wget http://getcomposer.org/composer.phar
+  - wget https://getcomposer.org/download/1.8.6/composer.phar
   - php composer.phar install --prefer-source
 
   - ./test/reset_tests.sh

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "phing/phing": "~2.4"
   },
   "require-dev": {
-    "pear-pear.php.net/PEAR_PackageFileManager2": "@stable",
+    "pear-pear.php.net/pear_packagefilemanager2": "@stable",
     "phpunit/phpunit": "~4.0||~5.0"
   },
   "extra": {


### PR DESCRIPTION
I noticed that the CI tests were failing due to a simple warning elevated to error about casing of the pear packages. So this is my attempt to resolve that issue.